### PR TITLE
Protocolv31

### DIFF
--- a/src/integrationTest/groovy/com/streamr/client/StreamrIntegrationSpecification.groovy
+++ b/src/integrationTest/groovy/com/streamr/client/StreamrIntegrationSpecification.groovy
@@ -11,7 +11,7 @@ import spock.lang.Specification
 class StreamrIntegrationSpecification extends Specification {
 
     protected final static DEFAULT_REST_URL = "http://localhost:8081/streamr-core/api/v1"
-    private final static DEFAULT_WEBSOCKET_URL = "ws://localhost:8890/api/v1/ws?controlLayerVersion=1&messageLayerVersion=30"
+    private final static DEFAULT_WEBSOCKET_URL = "ws://localhost:8890/api/v1/ws?controlLayerVersion=1&messageLayerVersion=31"
 
     protected static String generatePrivateKey() {
         byte[] array = new byte[32]

--- a/src/integrationTest/groovy/com/streamr/client/StreamrIntegrationSpecification.groovy
+++ b/src/integrationTest/groovy/com/streamr/client/StreamrIntegrationSpecification.groovy
@@ -2,6 +2,7 @@ package com.streamr.client
 
 import com.streamr.client.authentication.ApiKeyAuthenticationMethod
 import com.streamr.client.authentication.EthereumAuthenticationMethod
+import com.streamr.client.options.EncryptionOptions
 import com.streamr.client.options.SigningOptions
 import com.streamr.client.options.StreamrClientOptions
 import org.apache.commons.codec.binary.Hex
@@ -19,7 +20,7 @@ class StreamrIntegrationSpecification extends Specification {
     }
 
     protected static StreamrClient createUnauthenticatedClient() {
-        return new StreamrClient(new StreamrClientOptions(null, SigningOptions.getDefault(), DEFAULT_WEBSOCKET_URL, DEFAULT_REST_URL))
+        return new StreamrClient(new StreamrClientOptions(null, SigningOptions.getDefault(), EncryptionOptions.getDefault(), DEFAULT_WEBSOCKET_URL, DEFAULT_REST_URL))
     }
 
     protected static StreamrClient createClientWithPrivateKey(String privateKey = null) {
@@ -31,11 +32,11 @@ class StreamrIntegrationSpecification extends Specification {
     }
 
     protected static StreamrClientOptions createOptionsWithApiKey(String apiKey = null) {
-        return new StreamrClientOptions(new ApiKeyAuthenticationMethod(apiKey), SigningOptions.getDefault(), DEFAULT_WEBSOCKET_URL, DEFAULT_REST_URL)
+        return new StreamrClientOptions(new ApiKeyAuthenticationMethod(apiKey), SigningOptions.getDefault(), EncryptionOptions.getDefault(), DEFAULT_WEBSOCKET_URL, DEFAULT_REST_URL)
     }
 
     protected static StreamrClientOptions createOptionsWithPrivateKey(String privateKey = null) {
-        return new StreamrClientOptions(new EthereumAuthenticationMethod(privateKey), SigningOptions.getDefault(), DEFAULT_WEBSOCKET_URL, DEFAULT_REST_URL)
+        return new StreamrClientOptions(new EthereumAuthenticationMethod(privateKey), SigningOptions.getDefault(), EncryptionOptions.getDefault(), DEFAULT_WEBSOCKET_URL, DEFAULT_REST_URL)
     }
 
     protected String generateResourceName() {

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -234,11 +234,7 @@ public class StreamrClient extends StreamrRESTClient {
     }
 
     private void handleMessage(StreamMessage message, boolean isResend) throws SubscriptionNotFoundException {
-        try {
-            log.debug(message.getStreamId() + ": " + message.getContent().toString());
-        } catch (IOException e) {
-            throw new MalformedMessageException(message.toJson());
-        }
+        log.debug(message.getStreamId() + ": " + message.getSerializedContent());
 
         subscribedStreamsUtil.verifyStreamMessage(message);
         Subscription sub = subs.get(message.getStreamId(), message.getStreamPartition());

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -261,6 +261,8 @@ public class StreamrClient extends StreamrRESTClient {
                 this.websocket.send(req.toJson());
                 new PeriodicResend(websocket, options.getGapFillTimeout(), sub, e.getPublisherId(),
                     e.getMsgChainId(), getSessionToken()).start();
+            } catch (Exception e) {
+                log.error(e);
             }
         }
     }

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -80,7 +80,7 @@ public class StreamrClient extends StreamrRESTClient {
         if (options.getPublishSignedMsgs()) {
             signingUtil = new SigningUtil(((EthereumAuthenticationMethod) options.getAuthenticationMethod()).getAccount());
         }
-        msgCreationUtil = new MessageCreationUtil(publisherId, signingUtil);
+        msgCreationUtil = new MessageCreationUtil(publisherId, signingUtil, options.getEncryptionOptions().getPublisherGroupKeys());
 
         try {
             this.websocket = new WebSocketClient(new URI(options.getWebsocketApiUrl())) {
@@ -272,14 +272,21 @@ public class StreamrClient extends StreamrRESTClient {
      */
 
     public void publish(Stream stream, Map<String, Object> payload) {
-        publish(stream, payload, new Date());
+        publish(stream, payload, new Date(), null);
     }
 
     public void publish(Stream stream, Map<String, Object> payload, Date timestamp) {
+        publish(stream, payload, timestamp, null);
+    }
+
+    public void publish(Stream stream, Map<String, Object> payload, Date timestamp, String groupKeyHex) {
         if (!getState().equals(StreamrClient.State.Connected)) {
             connect();
         }
-        StreamMessage streamMessage = msgCreationUtil.createStreamMessage(stream, payload, timestamp, null);
+        if (groupKeyHex != null) {
+            options.getEncryptionOptions().getPublisherGroupKeys().put(stream.getId(), groupKeyHex);
+        }
+        StreamMessage streamMessage = msgCreationUtil.createStreamMessage(stream, payload, timestamp, null, groupKeyHex);
         PublishRequest req = new PublishRequest(streamMessage, getSessionToken());
         getWebsocket().send(req.toJson());
     }
@@ -293,8 +300,39 @@ public class StreamrClient extends StreamrRESTClient {
         if (nbPartitions != null && nbPartitions > 1) {
             throw new PartitionNotSpecifiedException(stream.getId(), stream.getPartitions());
         }
-        return subscribe(stream, 0, handler, null);
+        return subscribe(stream, 0, handler, null, null);
     }
+
+    public Subscription subscribe(Stream stream, int partition, MessageHandler handler, ResendOption resendOption) {
+        return subscribe(stream, partition, handler, resendOption, null);
+    }
+
+    public Subscription subscribe(Stream stream, int partition, MessageHandler handler, ResendOption resendOption,
+                                  Map<String, String> groupKeys) {
+        if (!getState().equals(State.Connected)) {
+            connect();
+        }
+
+        if (groupKeys != null) {
+            Map<String, String> keysPerPublisher = options.getEncryptionOptions().getSubscriberGroupKeys().get(stream.getId());
+            if (keysPerPublisher == null) {
+                options.getEncryptionOptions().getSubscriberGroupKeys().put(stream.getId(), new HashMap<>(groupKeys));
+            } else {
+                keysPerPublisher.putAll(groupKeys);
+            }
+        }
+
+        SubscribeRequest subscribeRequest = new SubscribeRequest(stream.getId(), partition, session.getSessionToken());
+        Subscription sub = new Subscription(stream.getId(), partition, handler, resendOption, groupKeys);
+        subs.add(sub);
+        sub.setState(Subscription.State.SUBSCRIBING);
+        this.websocket.send(subscribeRequest.toJson());
+        return sub;
+    }
+
+    /*
+     * Resend
+     */
 
     public void resend(Stream stream, int partition, MessageHandler handler, ResendOption resendOption) {
         StreamrClient s = this;
@@ -316,19 +354,6 @@ public class StreamrClient extends StreamrRESTClient {
         };
 
         subscribe(stream, partition, a, resendOption);
-    }
-
-    public Subscription subscribe(Stream stream, int partition, MessageHandler handler, ResendOption resendOption) {
-        if (!getState().equals(State.Connected)) {
-            connect();
-        }
-
-        SubscribeRequest subscribeRequest = new SubscribeRequest(stream.getId(), partition, session.getSessionToken());
-        Subscription sub = new Subscription(stream.getId(), partition, handler, resendOption);
-        subs.add(sub);
-        sub.setState(Subscription.State.SUBSCRIBING);
-        this.websocket.send(subscribeRequest.toJson());
-        return sub;
     }
 
     /*

--- a/src/main/java/com/streamr/client/Subscription.java
+++ b/src/main/java/com/streamr/client/Subscription.java
@@ -45,18 +45,20 @@ public class Subscription {
         this.streamPartition = new StreamPartition(streamId, partition);
         this.handler = handler;
         this.resendOption = resendOption;
-        for (String publisherId: groupKeysHex.keySet()) {
-            String groupKeyHex = groupKeysHex.get(publisherId);
-            groupKeys.put(publisherId, new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES"));
+        if (groupKeysHex != null) {
+            for (String publisherId: groupKeysHex.keySet()) {
+                String groupKeyHex = groupKeysHex.get(publisherId);
+                groupKeys.put(publisherId, new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES"));
+            }
         }
     }
 
     public Subscription(String streamId, int partition, MessageHandler handler, ResendOption resendOption) {
-        this(streamId, partition, handler, resendOption, new HashMap<>());
+        this(streamId, partition, handler, resendOption, null);
     }
 
     public Subscription(String streamId, int partition, MessageHandler handler) {
-        this(streamId, partition, handler, null, new HashMap<>());
+        this(streamId, partition, handler, null, null);
     }
 
     public String getId() {

--- a/src/main/java/com/streamr/client/Subscription.java
+++ b/src/main/java/com/streamr/client/Subscription.java
@@ -27,7 +27,7 @@ public class Subscription {
     private final StreamPartition streamPartition;
     private final MessageHandler handler;
     private ResendOption resendOption;
-    private final Map<String, SecretKey> groupKeys = new HashMap<>();
+    private final Map<String, SecretKey> groupKeys = new HashMap<>(); // publisherId --> groupKey
 
     private final HashMap<String, MessageRef> lastReceivedMsgRef = new HashMap<>();
     private boolean resending = false;

--- a/src/main/java/com/streamr/client/exceptions/ContentTypeNotParsableException.java
+++ b/src/main/java/com/streamr/client/exceptions/ContentTypeNotParsableException.java
@@ -1,0 +1,9 @@
+package com.streamr.client.exceptions;
+
+import com.streamr.client.protocol.message_layer.StreamMessage;
+
+public class ContentTypeNotParsableException extends RuntimeException {
+    public ContentTypeNotParsableException(StreamMessage.ContentType contentType) {
+        super("Content with content type " + contentType.getId() + " cannot get parsed. Use serializedContent() method.");
+    }
+}

--- a/src/main/java/com/streamr/client/exceptions/EncryptedContentNotParsableException.java
+++ b/src/main/java/com/streamr/client/exceptions/EncryptedContentNotParsableException.java
@@ -1,0 +1,9 @@
+package com.streamr.client.exceptions;
+
+import com.streamr.client.protocol.message_layer.StreamMessage;
+
+public class EncryptedContentNotParsableException extends RuntimeException {
+    public EncryptedContentNotParsableException(StreamMessage.EncryptionType encryptionType) {
+        super("Content cannot be parsed since it is encrypted with " + encryptionType.getId() + ". Use serializedContent() method.");
+    }
+}

--- a/src/main/java/com/streamr/client/exceptions/InvalidGroupKeyException.java
+++ b/src/main/java/com/streamr/client/exceptions/InvalidGroupKeyException.java
@@ -1,0 +1,9 @@
+package com.streamr.client.exceptions;
+
+public class InvalidGroupKeyException extends RuntimeException {
+
+    public InvalidGroupKeyException(int keyLength) {
+        super("Group key must be 256 bits long, but got a key length of " + keyLength + " bits.");
+    }
+
+}

--- a/src/main/java/com/streamr/client/exceptions/UnableToDecryptException.java
+++ b/src/main/java/com/streamr/client/exceptions/UnableToDecryptException.java
@@ -1,0 +1,9 @@
+package com.streamr.client.exceptions;
+
+public class UnableToDecryptException extends RuntimeException {
+
+    public UnableToDecryptException(String ciphertext) {
+        super("Unable to decrypt: " + (ciphertext.length() > 100 ? ciphertext.substring(0, 100) + "..." : ciphertext));
+    }
+
+}

--- a/src/main/java/com/streamr/client/exceptions/UnsupportedPayloadException.java
+++ b/src/main/java/com/streamr/client/exceptions/UnsupportedPayloadException.java
@@ -1,9 +1,0 @@
-package com.streamr.client.exceptions;
-
-public class UnsupportedPayloadException extends RuntimeException {
-
-    public UnsupportedPayloadException(String message) {
-        super(message);
-    }
-
-}

--- a/src/main/java/com/streamr/client/options/EncryptionOptions.java
+++ b/src/main/java/com/streamr/client/options/EncryptionOptions.java
@@ -1,0 +1,30 @@
+package com.streamr.client.options;
+
+import java.util.HashMap;
+
+public class EncryptionOptions {
+    private HashMap<String, String> publisherGroupKeys; // streamId --> groupKeyHex
+    private HashMap<String, HashMap<String, String>> subscriberGroupKeys; // streamId --> (publisherId --> groupKeyHex)
+
+    public EncryptionOptions() {
+        this.publisherGroupKeys = new HashMap<>();
+        this.subscriberGroupKeys = new HashMap<>();
+    }
+
+    public EncryptionOptions(HashMap<String, String> publisherGroupKeys, HashMap<String, HashMap<String, String>> subscriberGroupKeys) {
+        this.publisherGroupKeys = publisherGroupKeys;
+        this.subscriberGroupKeys = subscriberGroupKeys;
+    }
+
+    public HashMap<String, String> getPublisherGroupKeys() {
+        return publisherGroupKeys;
+    }
+
+    public HashMap<String, HashMap<String, String>> getSubscriberGroupKeys() {
+        return subscriberGroupKeys;
+    }
+
+    public static EncryptionOptions getDefault() {
+        return new EncryptionOptions();
+    }
+}

--- a/src/main/java/com/streamr/client/options/StreamrClientOptions.java
+++ b/src/main/java/com/streamr/client/options/StreamrClientOptions.java
@@ -4,10 +4,13 @@ import com.streamr.client.authentication.AuthenticationMethod;
 import com.streamr.client.authentication.EthereumAuthenticationMethod;
 import com.streamr.client.exceptions.InvalidOptionsException;
 
+import java.util.HashMap;
+
 public class StreamrClientOptions {
 
     private AuthenticationMethod authenticationMethod = null;
     private SigningOptions signingOptions = SigningOptions.getDefault();
+    private EncryptionOptions encryptionOptions = EncryptionOptions.getDefault();
     private boolean publishSignedMsgs = false;
     private String websocketApiUrl = "wss://www.streamr.com/api/v1/ws?controlLayerVersion=1&messageLayerVersion=30";
     private String restApiUrl = "https://www.streamr.com/api/v1";
@@ -37,17 +40,17 @@ public class StreamrClientOptions {
     }
 
     public StreamrClientOptions(AuthenticationMethod authenticationMethod, SigningOptions signingOptions,
-                                String websocketApiUrl, String restApiUrl) {
+                                EncryptionOptions encryptionOptions, String websocketApiUrl, String restApiUrl) {
         this(authenticationMethod, signingOptions);
+        this.encryptionOptions = encryptionOptions;
         this.websocketApiUrl = websocketApiUrl;
         this.restApiUrl = restApiUrl;
     }
 
     public StreamrClientOptions(AuthenticationMethod authenticationMethod, SigningOptions signingOptions,
-                                String websocketApiUrl, String restApiUrl, int gapFillTimeout, int retryResendAfter) {
-        this(authenticationMethod, signingOptions);
-        this.websocketApiUrl = websocketApiUrl;
-        this.restApiUrl = restApiUrl;
+                                EncryptionOptions encryptionOptions, String websocketApiUrl, String restApiUrl,
+                                int gapFillTimeout, int retryResendAfter) {
+        this(authenticationMethod, signingOptions, encryptionOptions, websocketApiUrl, restApiUrl);
         this.gapFillTimeout = gapFillTimeout;
         this.retryResendAfter = retryResendAfter;
     }
@@ -86,6 +89,10 @@ public class StreamrClientOptions {
 
     public SigningOptions getSigningOptions() {
         return signingOptions;
+    }
+
+    public EncryptionOptions getEncryptionOptions() {
+        return encryptionOptions;
     }
 
     public int getGapFillTimeout() {

--- a/src/main/java/com/streamr/client/protocol/message_layer/StreamMessage.java
+++ b/src/main/java/com/streamr/client/protocol/message_layer/StreamMessage.java
@@ -168,7 +168,7 @@ public abstract class StreamMessage implements ITimestamped {
         return encryptionType;
     }
 
-    public Map<String, Object> getContent() throws IOException {
+    public Map<String, Object> getContent() throws IOException, EncryptedContentNotParsableException {
         if (content == null) {
             if (encryptionType != EncryptionType.NONE) {
                 throw new EncryptedContentNotParsableException(encryptionType);
@@ -181,6 +181,32 @@ public abstract class StreamMessage implements ITimestamped {
 
     public String getSerializedContent() {
         return serializedContent;
+    }
+
+    public byte[] getSerializedContentAsBytes() {
+        return serializedContent.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public void setEncryptionType(EncryptionType encryptionType) {
+        this.encryptionType = encryptionType;
+    }
+
+    public void setSerializedContent(String serializedContent) throws IOException {
+        this.serializedContent = serializedContent;
+        if (this.encryptionType == EncryptionType.NONE) {
+            this.content = HttpUtils.mapAdapter.fromJson(serializedContent);
+            validateContent(content, contentType);
+        }
+    }
+
+    public void setSerializedContent(byte[] serializedContent) throws IOException {
+        setSerializedContent(new String(serializedContent, StandardCharsets.UTF_8));
+    }
+
+    public void setContent(Map<String, Object> content) {
+        validateContent(content, contentType);
+        this.content = content;
+        this.serializedContent = HttpUtils.mapAdapter.toJson(content);
     }
 
     public abstract SignatureType getSignatureType();

--- a/src/main/java/com/streamr/client/protocol/message_layer/StreamMessage.java
+++ b/src/main/java/com/streamr/client/protocol/message_layer/StreamMessage.java
@@ -13,7 +13,6 @@ import com.streamr.client.exceptions.EncryptedContentNotParsableException;
 import com.streamr.client.exceptions.MalformedMessageException;
 import com.streamr.client.utils.HttpUtils;
 import com.streamr.client.exceptions.UnsupportedMessageException;
-import kotlin.TypeCastException;
 import okio.Buffer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageAdapter.java
@@ -20,6 +20,7 @@ public class StreamMessageAdapter extends JsonAdapter<StreamMessage> {
     private static final StreamMessageV28Adapter v28Adapter = new StreamMessageV28Adapter();
     private static final StreamMessageV29Adapter v29Adapter = new StreamMessageV29Adapter();
     private static final StreamMessageV30Adapter v30Adapter = new StreamMessageV30Adapter();
+    private static final StreamMessageV31Adapter v31Adapter = new StreamMessageV31Adapter();
 
     @Override
     public StreamMessage fromJson(JsonReader reader) throws IOException {
@@ -35,6 +36,8 @@ public class StreamMessageAdapter extends JsonAdapter<StreamMessage> {
                 msg = v29Adapter.fromJson(reader);
             } else if (version == StreamMessageV30.VERSION) {
                 msg = v30Adapter.fromJson(reader);
+            } else if (version == StreamMessageV31.VERSION) {
+                msg = v31Adapter.fromJson(reader);
             } else {
                 throw new UnsupportedMessageException("Unrecognized stream message version: " + version);
             }
@@ -57,6 +60,8 @@ public class StreamMessageAdapter extends JsonAdapter<StreamMessage> {
             v29Adapter.toJson(writer, (StreamMessageV29) value);
         } else if (version == StreamMessageV30.VERSION) {
             v30Adapter.toJson(writer, (StreamMessageV30) value);
+        } else if (version == StreamMessageV31.VERSION) {
+            v31Adapter.toJson(writer, (StreamMessageV31) value);
         } else {
             throw new UnsupportedMessageException("Unrecognized stream message version: " + version);
         }

--- a/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageV28.java
+++ b/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageV28.java
@@ -15,7 +15,7 @@ public class StreamMessageV28 extends StreamMessage {
 
     public StreamMessageV28(String streamId, int streamPartition, long timestamp, Integer ttl, Long offset,
                             Long previousOffset, ContentType contentType, String serializedContent) throws IOException {
-        super(VERSION, contentType, serializedContent);
+        super(VERSION, contentType, EncryptionType.NONE, serializedContent);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
         this.timestamp = timestamp;
@@ -26,7 +26,7 @@ public class StreamMessageV28 extends StreamMessage {
 
     public StreamMessageV28(String streamId, int streamPartition, long timestamp, Integer ttl, Long offset,
                             Long previousOffset, ContentType contentType, Map<String, Object> content) {
-        super(VERSION, contentType, content);
+        super(VERSION, contentType, EncryptionType.NONE, content);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
         this.timestamp = timestamp;

--- a/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageV29.java
+++ b/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageV29.java
@@ -19,7 +19,7 @@ public class StreamMessageV29 extends StreamMessage {
     public StreamMessageV29(String streamId, int streamPartition, long timestamp, Integer ttl, Long offset,
                             Long previousOffset, ContentType contentType, String serializedContent,
                             SignatureType signatureType, String publisherAddress, String signature) throws IOException {
-        super(VERSION, contentType, serializedContent);
+        super(VERSION, contentType, EncryptionType.NONE, serializedContent);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
         this.timestamp = timestamp;
@@ -34,7 +34,7 @@ public class StreamMessageV29 extends StreamMessage {
     public StreamMessageV29(String streamId, int streamPartition, long timestamp, Integer ttl, Long offset,
                             Long previousOffset, ContentType contentType, Map<String, Object> content,
                             SignatureType signatureType, String publisherAddress, String signature) throws IOException {
-        super(VERSION, contentType, content);
+        super(VERSION, contentType, EncryptionType.NONE, content);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
         this.timestamp = timestamp;

--- a/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageV31.java
+++ b/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageV31.java
@@ -2,36 +2,38 @@ package com.streamr.client.protocol.message_layer;
 
 import java.util.Map;
 
-public class StreamMessageV30 extends StreamMessage {
+public class StreamMessageV31 extends StreamMessage {
 
-    public static final int VERSION = 30;
+    public static final int VERSION = 31;
     private MessageID messageID;
     private MessageRef previousMessageRef;
     private SignatureType signatureType;
     private String signature;
 
-    public StreamMessageV30(MessageID messageID, MessageRef previousMessageRef, ContentType contentType,
+    public StreamMessageV31(MessageID messageID, MessageRef previousMessageRef, ContentType contentType, EncryptionType encryptionType,
                             String serializedContent, SignatureType signatureType, String signature) {
-        super(VERSION, contentType, EncryptionType.NONE, serializedContent);
+        super(VERSION, contentType, encryptionType, serializedContent);
         this.messageID = messageID;
         this.previousMessageRef = previousMessageRef;
         this.signatureType = signatureType;
         this.signature = signature;
     }
 
-    public StreamMessageV30(MessageID messageID, MessageRef previousMessageRef, ContentType contentType,
-                            Map<String, Object> content, SignatureType signatureType, String signature) {
-        super(VERSION, contentType, EncryptionType.NONE, content);
+    public StreamMessageV31(MessageID messageID, MessageRef previousMessageRef, ContentType contentType,
+                            EncryptionType encryptionType, Map<String, Object> content,
+                            SignatureType signatureType, String signature) {
+        super(VERSION, contentType, encryptionType, content);
         this.messageID = messageID;
         this.previousMessageRef = previousMessageRef;
         this.signatureType = signatureType;
         this.signature = signature;
     }
 
-    public StreamMessageV30(String streamId, int streamPartition, long timestamp, long sequenceNumber,
-                            String publisherId, String msgChainId, Long previousTimestamp, Long previousSequenceNumber, ContentType contentType,
+    public StreamMessageV31(String streamId, int streamPartition, long timestamp, long sequenceNumber,
+                            String publisherId, String msgChainId, Long previousTimestamp, Long previousSequenceNumber,
+                            ContentType contentType, EncryptionType encryptionType,
                             String serializedContent, SignatureType signatureType, String signature) {
-        super(VERSION, contentType, EncryptionType.NONE, serializedContent);
+        super(VERSION, contentType, encryptionType, serializedContent);
         this.messageID = new MessageID(streamId, streamPartition, timestamp, sequenceNumber, publisherId, msgChainId);
         if (previousTimestamp == null) {
             this.previousMessageRef = null;
@@ -42,10 +44,11 @@ public class StreamMessageV30 extends StreamMessage {
         this.signature = signature;
     }
 
-    public StreamMessageV30(String streamId, int streamPartition, long timestamp, long sequenceNumber,
-                            String publisherId, String msgChainId, Long previousTimestamp, Long previousSequenceNumber, ContentType contentType,
+    public StreamMessageV31(String streamId, int streamPartition, long timestamp, long sequenceNumber,
+                            String publisherId, String msgChainId, Long previousTimestamp, Long previousSequenceNumber,
+                            ContentType contentType, EncryptionType encryptionType,
                             Map<String, Object> content, SignatureType signatureType, String signature) {
-        super(VERSION, contentType, EncryptionType.NONE, content);
+        super(VERSION, contentType, encryptionType, content);
         this.messageID = new MessageID(streamId, streamPartition, timestamp, sequenceNumber, publisherId, msgChainId);
         if (previousTimestamp == null) {
             this.previousMessageRef = null;

--- a/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageV31Adapter.java
+++ b/src/main/java/com/streamr/client/protocol/message_layer/StreamMessageV31Adapter.java
@@ -1,0 +1,65 @@
+package com.streamr.client.protocol.message_layer;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.streamr.client.exceptions.MalformedMessageException;
+import com.streamr.client.protocol.message_layer.StreamMessage.ContentType;
+import com.streamr.client.protocol.message_layer.StreamMessage.SignatureType;
+import com.streamr.client.protocol.message_layer.StreamMessage.EncryptionType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+
+public class StreamMessageV31Adapter extends JsonAdapter<StreamMessageV31> {
+
+    private static final Logger log = LogManager.getLogger();
+    private static final MessageIDAdapter msgIdAdapter = new MessageIDAdapter();
+    private static final MessageRefAdapter msgRefAdapter = new MessageRefAdapter();
+
+    @Override
+    public StreamMessageV31 fromJson(JsonReader reader) throws IOException {
+        try {
+            MessageID messageID = msgIdAdapter.fromJson(reader);
+            MessageRef previousMessageRef = null;
+            // Peek at the previousMessageRef, as it can be null
+            if (reader.peek().equals(JsonReader.Token.NULL)) {
+                reader.nextNull();
+            } else {
+                previousMessageRef = msgRefAdapter.fromJson(reader);
+            }
+            ContentType contentType = ContentType.fromId((byte)reader.nextInt());
+            EncryptionType encryptionType = EncryptionType.fromId((byte)reader.nextInt());
+            String serializedContent = reader.nextString();
+            SignatureType signatureType = SignatureType.fromId((byte)reader.nextInt());
+            String signature = null;
+            if (signatureType != SignatureType.SIGNATURE_TYPE_NONE) {
+                signature = reader.nextString();
+            } else {
+                reader.nextNull();
+            }
+
+            return new StreamMessageV31(messageID, previousMessageRef, contentType, encryptionType, serializedContent, signatureType, signature);
+        } catch (JsonDataException e) {
+            log.error(e);
+            throw new MalformedMessageException("Malformed message: " + reader.toString(), e);
+        }
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, StreamMessageV31 value) throws IOException {
+        msgIdAdapter.toJson(writer, value.getMessageID());
+        if (value.getPreviousMessageRef() != null) {
+            msgRefAdapter.toJson(writer, value.getPreviousMessageRef());
+        }else {
+            writer.value((String)null);
+        }
+        writer.value(value.getContentType().getId());
+        writer.value(value.getEncryptionType().getId());
+        writer.value(value.getSerializedContent());
+        writer.value(value.getSignatureType().getId());
+        writer.value(value.getSignature());
+    }
+}

--- a/src/main/java/com/streamr/client/utils/EncryptionUtil.java
+++ b/src/main/java/com/streamr/client/utils/EncryptionUtil.java
@@ -1,0 +1,47 @@
+package com.streamr.client.utils;
+
+import com.streamr.client.exceptions.InvalidGroupKeyException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.xml.bind.DatatypeConverter;
+import java.security.SecureRandom;
+
+public class EncryptionUtil {
+    private static final Logger log = LogManager.getLogger();
+    private static final SecureRandom SRAND = new SecureRandom();
+
+    public static String encrypt(byte[] plaintext, SecretKey groupKey) {
+        try {
+            Cipher encryptCipher = Cipher.getInstance("AES/CTR/NoPadding");
+            byte[] iv = new byte[16];
+            SRAND.nextBytes(iv);
+            IvParameterSpec ivspec = new IvParameterSpec(iv);
+            encryptCipher.init(Cipher.ENCRYPT_MODE, groupKey, ivspec);
+            byte[] ciphertext = encryptCipher.doFinal(plaintext);
+            return Hex.encodeHexString(iv) + Hex.encodeHexString(ciphertext);
+        } catch (Exception e) {
+            log.error(e);
+        }
+        return null;
+    }
+
+    public static byte[] decrypt(String ciphertext, SecretKey groupKey) throws Exception {
+        Cipher decryptCipher = Cipher.getInstance("AES/CTR/NoPadding");
+        byte[] iv = DatatypeConverter.parseHexBinary(ciphertext.substring(0, 32));
+        IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
+        decryptCipher.init(Cipher.DECRYPT_MODE, groupKey, ivParameterSpec);
+        return decryptCipher.doFinal(DatatypeConverter.parseHexBinary(ciphertext.substring(32)));
+    }
+
+    public static void validateGroupKey(String groupKeyHex) {
+        String without0x = groupKeyHex.startsWith("0x") ? groupKeyHex.substring(2) : groupKeyHex;
+        if (without0x.length() != 64) { // the key must be 256 bits long
+            throw new InvalidGroupKeyException(without0x.length() * 4);
+        }
+    }
+}

--- a/src/main/java/com/streamr/client/utils/EncryptionUtil.java
+++ b/src/main/java/com/streamr/client/utils/EncryptionUtil.java
@@ -1,6 +1,8 @@
 package com.streamr.client.utils;
 
 import com.streamr.client.exceptions.InvalidGroupKeyException;
+import com.streamr.client.exceptions.UnableToDecryptException;
+import com.streamr.client.protocol.message_layer.StreamMessage;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -8,21 +10,33 @@ import org.apache.logging.log4j.Logger;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
+import java.io.IOException;
 import java.security.SecureRandom;
+import java.util.Arrays;
 
 public class EncryptionUtil {
     private static final Logger log = LogManager.getLogger();
     private static final SecureRandom SRAND = new SecureRandom();
+    private static final Cipher cipher = getCipher();
+
+    private static Cipher getCipher() {
+        try {
+            return Cipher.getInstance("AES/CTR/NoPadding");
+        } catch (Exception e) {
+            log.error(e);
+            throw new RuntimeException(e);
+        }
+    }
 
     public static String encrypt(byte[] plaintext, SecretKey groupKey) {
         try {
-            Cipher encryptCipher = Cipher.getInstance("AES/CTR/NoPadding");
             byte[] iv = new byte[16];
             SRAND.nextBytes(iv);
             IvParameterSpec ivspec = new IvParameterSpec(iv);
-            encryptCipher.init(Cipher.ENCRYPT_MODE, groupKey, ivspec);
-            byte[] ciphertext = encryptCipher.doFinal(plaintext);
+            cipher.init(Cipher.ENCRYPT_MODE, groupKey, ivspec);
+            byte[] ciphertext = cipher.doFinal(plaintext);
             return Hex.encodeHexString(iv) + Hex.encodeHexString(ciphertext);
         } catch (Exception e) {
             log.error(e);
@@ -31,11 +45,57 @@ public class EncryptionUtil {
     }
 
     public static byte[] decrypt(String ciphertext, SecretKey groupKey) throws Exception {
-        Cipher decryptCipher = Cipher.getInstance("AES/CTR/NoPadding");
         byte[] iv = DatatypeConverter.parseHexBinary(ciphertext.substring(0, 32));
         IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
-        decryptCipher.init(Cipher.DECRYPT_MODE, groupKey, ivParameterSpec);
-        return decryptCipher.doFinal(DatatypeConverter.parseHexBinary(ciphertext.substring(32)));
+        cipher.init(Cipher.DECRYPT_MODE, groupKey, ivParameterSpec);
+        return cipher.doFinal(DatatypeConverter.parseHexBinary(ciphertext.substring(32)));
+    }
+
+    /*
+    Sets the content of 'streamMessage' to be the result of the encryption of the old content with 'groupKey'.
+     */
+    public static void encryptStreamMessage(StreamMessage streamMessage, SecretKey groupKey) {
+        streamMessage.setEncryptionType(StreamMessage.EncryptionType.AES);
+        try {
+            streamMessage.setSerializedContent(encrypt(streamMessage.getSerializedContentAsBytes(), groupKey));
+        } catch (IOException e) {
+            log.error(e);
+        }
+    }
+
+    /*
+    Sets the content of the StreamMessage to be the result of the encryption of a plaintext with 'groupKey'. The
+    plaintext is the concatenation of 'newGroupKeyHex' and the old serialized content of 'streamMessage'.
+     */
+    public static void encryptStreamMessageAndNewKey(String newGroupKeyHex, StreamMessage streamMessage, SecretKey groupKey) {
+        streamMessage.setEncryptionType(StreamMessage.EncryptionType.NEW_KEY_AND_AES);
+        byte[] groupKeyBytes = DatatypeConverter.parseHexBinary(newGroupKeyHex);
+        byte[] payloadBytes = streamMessage.getSerializedContentAsBytes();
+        byte[] plaintext = new byte[groupKeyBytes.length + payloadBytes.length];
+        System.arraycopy(groupKeyBytes, 0, plaintext, 0, groupKeyBytes.length);
+        System.arraycopy(payloadBytes, 0, plaintext, groupKeyBytes.length, payloadBytes.length);
+        try {
+            streamMessage.setSerializedContent(encrypt(plaintext, groupKey));
+        } catch (IOException e) {
+            log.error(e);
+        }
+    }
+
+    public static SecretKey decryptStreamMessage(StreamMessage streamMessage, SecretKey groupKey) throws UnableToDecryptException {
+        try {
+            if (streamMessage.getEncryptionType() == StreamMessage.EncryptionType.AES) {
+                streamMessage.setEncryptionType(StreamMessage.EncryptionType.NONE);
+                streamMessage.setSerializedContent(decrypt(streamMessage.getSerializedContent(), groupKey));
+            } else if (streamMessage.getEncryptionType() == StreamMessage.EncryptionType.NEW_KEY_AND_AES) {
+                byte[] plaintext = EncryptionUtil.decrypt(streamMessage.getSerializedContent(), groupKey);
+                streamMessage.setEncryptionType(StreamMessage.EncryptionType.NONE);
+                streamMessage.setSerializedContent(Arrays.copyOfRange(plaintext, 32, plaintext.length));
+                return new SecretKeySpec(Arrays.copyOfRange(plaintext, 0, 32), "AES");
+            }
+        } catch (Exception e) {
+            throw new UnableToDecryptException(streamMessage.getSerializedContent());
+        }
+        return null;
     }
 
     public static void validateGroupKey(String groupKeyHex) {

--- a/src/main/java/com/streamr/client/utils/EncryptionUtil.java
+++ b/src/main/java/com/streamr/client/utils/EncryptionUtil.java
@@ -52,7 +52,7 @@ public class EncryptionUtil {
     }
 
     /*
-    Sets the content of 'streamMessage' to be the result of the encryption of the old content with 'groupKey'.
+    Sets the content of 'streamMessage' with the encryption result of the old content with 'groupKey'.
      */
     public static void encryptStreamMessage(StreamMessage streamMessage, SecretKey groupKey) {
         streamMessage.setEncryptionType(StreamMessage.EncryptionType.AES);
@@ -64,7 +64,7 @@ public class EncryptionUtil {
     }
 
     /*
-    Sets the content of the StreamMessage to be the result of the encryption of a plaintext with 'groupKey'. The
+    Sets the content of 'streamMessage' with the encryption result of a plaintext with 'groupKey'. The
     plaintext is the concatenation of 'newGroupKeyHex' and the old serialized content of 'streamMessage'.
      */
     public static void encryptStreamMessageAndNewKey(String newGroupKeyHex, StreamMessage streamMessage, SecretKey groupKey) {
@@ -81,6 +81,12 @@ public class EncryptionUtil {
         }
     }
 
+    /*
+    Decrypts the serialized content of 'streamMessage' with 'groupKey'. If the resulting plaintext is the concatenation
+    of a new group key and a message content, sets the content of 'streamMessage' with that message content and returns
+    the key. If the resulting plaintext is only a message content, sets the content of 'streamMessage' with that
+    message content and returns null.
+     */
     public static SecretKey decryptStreamMessage(StreamMessage streamMessage, SecretKey groupKey) throws UnableToDecryptException {
         try {
             if (streamMessage.getEncryptionType() == StreamMessage.EncryptionType.AES) {

--- a/src/main/java/com/streamr/client/utils/EncryptionUtil.java
+++ b/src/main/java/com/streamr/client/utils/EncryptionUtil.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 public class EncryptionUtil {
     private static final Logger log = LogManager.getLogger();
     private static final SecureRandom SRAND = new SecureRandom();
-    private static final Cipher cipher = getCipher();
+    private static final ThreadLocal<Cipher> cipher = ThreadLocal.withInitial(() -> getCipher());
 
     private static Cipher getCipher() {
         try {
@@ -35,8 +35,8 @@ public class EncryptionUtil {
             byte[] iv = new byte[16];
             SRAND.nextBytes(iv);
             IvParameterSpec ivspec = new IvParameterSpec(iv);
-            cipher.init(Cipher.ENCRYPT_MODE, groupKey, ivspec);
-            byte[] ciphertext = cipher.doFinal(plaintext);
+            cipher.get().init(Cipher.ENCRYPT_MODE, groupKey, ivspec);
+            byte[] ciphertext = cipher.get().doFinal(plaintext);
             return Hex.encodeHexString(iv) + Hex.encodeHexString(ciphertext);
         } catch (Exception e) {
             log.error(e);
@@ -47,8 +47,8 @@ public class EncryptionUtil {
     public static byte[] decrypt(String ciphertext, SecretKey groupKey) throws Exception {
         byte[] iv = DatatypeConverter.parseHexBinary(ciphertext.substring(0, 32));
         IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
-        cipher.init(Cipher.DECRYPT_MODE, groupKey, ivParameterSpec);
-        return cipher.doFinal(DatatypeConverter.parseHexBinary(ciphertext.substring(32)));
+        cipher.get().init(Cipher.DECRYPT_MODE, groupKey, ivParameterSpec);
+        return cipher.get().doFinal(DatatypeConverter.parseHexBinary(ciphertext.substring(32)));
     }
 
     /*

--- a/src/main/java/com/streamr/client/utils/MessageCreationUtil.java
+++ b/src/main/java/com/streamr/client/utils/MessageCreationUtil.java
@@ -1,52 +1,44 @@
 package com.streamr.client.utils;
 
-import com.streamr.client.exceptions.InvalidGroupKeyException;
 import com.streamr.client.protocol.message_layer.*;
 import com.streamr.client.protocol.message_layer.StreamMessage.EncryptionType;
 import com.streamr.client.rest.Stream;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 public class MessageCreationUtil {
-    private static final Logger log = LogManager.getLogger();
-    private static final SecureRandom SRAND = new SecureRandom();
 
     private final String publisherId;
     private final String msgChainId;
     private final SigningUtil signingUtil;
-    private SecretKey groupKey;
+    private final Map<String, SecretKey> groupKeys = new HashMap<>();
 
     private final HashMap<String, MessageRef> refsPerStreamAndPartition = new HashMap<>();
 
     private final HashMap<String, Integer> cachedHashes = new HashMap<>();
 
     public MessageCreationUtil(String publisherId, SigningUtil signingUtil) {
-        this(publisherId, signingUtil, null);
+        this(publisherId, signingUtil, new HashMap<>());
     }
 
-    public MessageCreationUtil(String publisherId, SigningUtil signingUtil, String groupKeyHex) {
+    public MessageCreationUtil(String publisherId, SigningUtil signingUtil, Map<String, String> groupKeysHex) {
         this.publisherId = publisherId;
         msgChainId = RandomStringUtils.randomAlphanumeric(20);
         this.signingUtil = signingUtil;
-        if (groupKeyHex != null) {
-            validateGroupKey(groupKeyHex);
-            groupKey = new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES");
+        for (String streamId: groupKeysHex.keySet()) {
+            String groupKeyHex = groupKeysHex.get(streamId);
+            EncryptionUtil.validateGroupKey(groupKeyHex);
+            groupKeys.put(streamId, new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES"));
         }
     }
 
@@ -56,26 +48,26 @@ public class MessageCreationUtil {
 
     public StreamMessage createStreamMessage(Stream stream, Map<String, Object> payload, Date timestamp, String partitionKey, String groupKeyHex) {
         if (groupKeyHex != null) {
-            validateGroupKey(groupKeyHex);
+            EncryptionUtil.validateGroupKey(groupKeyHex);
         }
 
         EncryptionType encryptionType;
         String content;
-        if (groupKey != null && groupKeyHex != null) {
+        if (groupKeys.containsKey(stream.getId()) && groupKeyHex != null) {
             encryptionType = EncryptionType.NEW_KEY_AND_AES;
             byte[] groupKeyBytes = DatatypeConverter.parseHexBinary(groupKeyHex);
             byte[] payloadBytes = HttpUtils.mapAdapter.toJson(payload).getBytes(StandardCharsets.UTF_8);
             byte[] plaintext = new byte[groupKeyBytes.length + payloadBytes.length];
             System.arraycopy(groupKeyBytes, 0, plaintext, 0, groupKeyBytes.length);
             System.arraycopy(payloadBytes, 0, plaintext, groupKeyBytes.length, payloadBytes.length);
-            content = encrypt(plaintext);
-            groupKey = new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES");
-        } else if (groupKeyHex != null || groupKey != null) {
+            content = EncryptionUtil.encrypt(plaintext, groupKeys.get(stream.getId()));
+            groupKeys.put(stream.getId(), new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES"));
+        } else if (groupKeys.containsKey(stream.getId()) || groupKeyHex != null) {
             if (groupKeyHex != null) {
-                groupKey = new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES");
+                groupKeys.put(stream.getId(), new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES"));
             }
             encryptionType = EncryptionType.AES;
-            content = encrypt(HttpUtils.mapAdapter.toJson(payload).getBytes(StandardCharsets.UTF_8));
+            content = EncryptionUtil.encrypt(HttpUtils.mapAdapter.toJson(payload).getBytes(StandardCharsets.UTF_8), groupKeys.get(stream.getId()));
         } else {
             encryptionType = EncryptionType.NONE;
             content = HttpUtils.mapAdapter.toJson(payload);
@@ -132,27 +124,5 @@ public class MessageCreationUtil {
             return 0L;
         }
         return prev.getSequenceNumber() + 1L;
-    }
-
-    private String encrypt(byte[] plaintext) {
-        try {
-            Cipher encryptCipher = Cipher.getInstance("AES/CTR/NoPadding");
-            byte[] iv = new byte[16];
-            SRAND.nextBytes(iv);
-            IvParameterSpec ivspec = new IvParameterSpec(iv);
-            encryptCipher.init(Cipher.ENCRYPT_MODE, groupKey, ivspec);
-            byte[] ciphertext = encryptCipher.doFinal(plaintext);
-            return Hex.encodeHexString(iv) + Hex.encodeHexString(ciphertext);
-        } catch (Exception e) {
-            log.error(e);
-        }
-        return null;
-    }
-
-    private static void validateGroupKey(String groupKeyHex) {
-        String without0x = groupKeyHex.startsWith("0x") ? groupKeyHex.substring(2) : groupKeyHex;
-        if (without0x.length() != 64) { // the key must be 256 bits long
-            throw new InvalidGroupKeyException(without0x.length() * 4);
-        }
     }
 }

--- a/src/main/java/com/streamr/client/utils/MessageCreationUtil.java
+++ b/src/main/java/com/streamr/client/utils/MessageCreationUtil.java
@@ -21,7 +21,7 @@ public class MessageCreationUtil {
     private final String publisherId;
     private final String msgChainId;
     private final SigningUtil signingUtil;
-    private final Map<String, SecretKey> groupKeys = new HashMap<>();
+    private final Map<String, SecretKey> groupKeys = new HashMap<>(); // streamId --> groupKey
 
     private final HashMap<String, MessageRef> refsPerStreamAndPartition = new HashMap<>();
 

--- a/src/main/java/com/streamr/client/utils/MessageCreationUtil.java
+++ b/src/main/java/com/streamr/client/utils/MessageCreationUtil.java
@@ -62,9 +62,6 @@ public class MessageCreationUtil {
         );
 
         refsPerStreamAndPartition.put(key, new MessageRef(timestamp.getTime(), sequenceNumber));
-        if (signingUtil != null) {
-            signingUtil.signStreamMessage(streamMessage);
-        }
 
         if (groupKeys.containsKey(stream.getId()) && groupKeyHex != null) {
             EncryptionUtil.encryptStreamMessageAndNewKey(groupKeyHex, streamMessage, groupKeys.get(stream.getId()));
@@ -74,6 +71,10 @@ public class MessageCreationUtil {
                 groupKeys.put(stream.getId(), new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES"));
             }
             EncryptionUtil.encryptStreamMessage(streamMessage, groupKeys.get(stream.getId()));
+        }
+
+        if (signingUtil != null) {
+            signingUtil.signStreamMessage(streamMessage);
         }
         return streamMessage;
     }

--- a/src/main/java/com/streamr/client/utils/MessageCreationUtil.java
+++ b/src/main/java/com/streamr/client/utils/MessageCreationUtil.java
@@ -3,36 +3,75 @@ package com.streamr.client.utils;
 import com.streamr.client.protocol.message_layer.MessageID;
 import com.streamr.client.protocol.message_layer.MessageRef;
 import com.streamr.client.protocol.message_layer.StreamMessage;
+import com.streamr.client.protocol.message_layer.StreamMessage.EncryptionType;
 import com.streamr.client.protocol.message_layer.StreamMessageV30;
 import com.streamr.client.rest.Stream;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 public class MessageCreationUtil {
+    private static final Logger log = LogManager.getLogger();
+    private static final SecureRandom SRAND = new SecureRandom();
+
     private final String publisherId;
     private final String msgChainId;
     private final SigningUtil signingUtil;
+    private SecretKey groupKey;
 
     private final HashMap<String, MessageRef> refsPerStreamAndPartition = new HashMap<>();
 
     private final HashMap<String, Integer> cachedHashes = new HashMap<>();
 
     public MessageCreationUtil(String publisherId, SigningUtil signingUtil) {
+        this(publisherId, signingUtil, null);
+    }
+
+    public MessageCreationUtil(String publisherId, SigningUtil signingUtil, String groupKeyHex) {
         this.publisherId = publisherId;
         msgChainId = RandomStringUtils.randomAlphanumeric(20);
         this.signingUtil = signingUtil;
+        if (groupKeyHex != null) {
+            groupKey = new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES");
+        }
     }
 
     public StreamMessage createStreamMessage(Stream stream, Map<String, Object> payload, Date timestamp, String partitionKey) {
+        return createStreamMessage(stream, payload, timestamp, partitionKey, null);
+    }
+
+    public StreamMessage createStreamMessage(Stream stream, Map<String, Object> payload, Date timestamp, String partitionKey, String groupKeyHex) {
+        EncryptionType encryptionType = EncryptionType.NONE;
+        String content;
+        if (groupKey != null && groupKeyHex != null) {
+            encryptionType = EncryptionType.NEW_KEY_AND_AES;
+            byte[] payloadBytes = HttpUtils.mapAdapter.toJson(payload).getBytes(StandardCharsets.UTF_8);
+            byte[] groupKexBytes = DatatypeConverter.parseHexBinary(groupKeyHex);
+            groupKey = new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES");
+        } else if (groupKeyHex != null || groupKey != null) {
+            if (groupKeyHex != null) {
+                groupKey = new SecretKeySpec(DatatypeConverter.parseHexBinary(groupKeyHex), "AES");
+            }
+            encryptionType = EncryptionType.AES;
+            content = encrypt(HttpUtils.mapAdapter.toJson(payload).getBytes(StandardCharsets.UTF_8));
+        }
         int streamPartition = getStreamPartition(stream.getPartitions(), partitionKey);
-        String key = stream.getId()+streamPartition;
+        String key = stream.getId() + streamPartition;
 
         long sequenceNumber = getNextSequenceNumber(key, timestamp.getTime());
         MessageID msgId = new MessageID(stream.getId(), streamPartition, timestamp.getTime(), sequenceNumber, publisherId, msgChainId);
@@ -83,5 +122,20 @@ public class MessageCreationUtil {
             return 0L;
         }
         return prev.getSequenceNumber() + 1L;
+    }
+
+    private String encrypt(byte[] plaintext) {
+        try {
+            Cipher encryptCipher = Cipher.getInstance("AES/CTR/NoPadding");
+            byte[] iv = new byte[16];
+            SRAND.nextBytes(iv);
+            IvParameterSpec ivspec = new IvParameterSpec(iv);
+            encryptCipher.init(Cipher.ENCRYPT_MODE, groupKey, ivspec);
+            byte[] ciphertext = encryptCipher.doFinal(plaintext);
+            return Hex.encodeHexString(iv) + Hex.encodeHexString(ciphertext);
+        } catch (Exception e) {
+            log.error(e);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/streamr/client/utils/SigningUtil.java
+++ b/src/main/java/com/streamr/client/utils/SigningUtil.java
@@ -23,8 +23,8 @@ public class SigningUtil {
     }
 
     public void signStreamMessage(StreamMessage msg, StreamMessage.SignatureType signatureType) {
-        if (msg.getVersion() != 30) {
-            throw new UnsupportedMessageException("Can only sign most recent StreamMessage version (30).");
+        if (msg.getVersion() < 30) {
+            throw new UnsupportedMessageException("Can only sign most recent StreamMessage versions (30 and 31).");
         }
         String signature = sign(getPayloadToSignOrVerify(msg, signatureType), account);
         msg.setSignatureType(signatureType);

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -1,5 +1,6 @@
 package com.streamr.client
 
+import com.streamr.client.options.EncryptionOptions
 import com.streamr.client.options.ResendLastOption
 import com.streamr.client.options.SigningOptions
 import com.streamr.client.options.StreamrClientOptions
@@ -36,7 +37,7 @@ class StreamrClientSpec extends Specification {
     void setup() {
         server.clear()
         SigningOptions signingOptions = new SigningOptions(SigningOptions.SignatureComputationPolicy.NEVER, SigningOptions.SignatureVerificationPolicy.NEVER)
-        StreamrClientOptions options = new StreamrClientOptions(null, signingOptions, server.getWsUrl(), "", gapFillTimeout, retryResendAfter)
+        StreamrClientOptions options = new StreamrClientOptions(null, signingOptions, EncryptionOptions.getDefault(), server.getWsUrl(), "", gapFillTimeout, retryResendAfter)
         client = new TestingStreamrClient(options)
     }
 

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -14,7 +14,7 @@ import com.streamr.client.protocol.control_layer.UnicastMessage
 import com.streamr.client.protocol.message_layer.MessageID
 import com.streamr.client.protocol.message_layer.MessageRef
 import com.streamr.client.protocol.message_layer.StreamMessage
-import com.streamr.client.protocol.message_layer.StreamMessageV30
+import com.streamr.client.protocol.message_layer.StreamMessageV31
 import com.streamr.client.rest.Stream
 import spock.lang.Specification
 
@@ -41,10 +41,10 @@ class StreamrClientSpec extends Specification {
         client = new TestingStreamrClient(options)
     }
 
-    StreamMessageV30 createMsg(String streamId, long timestamp, long sequenceNumber, Long prevTimestamp, Long prevSequenceNumber) {
+    StreamMessageV31 createMsg(String streamId, long timestamp, long sequenceNumber, Long prevTimestamp, Long prevSequenceNumber) {
         MessageID msgId = new MessageID(streamId, 0, timestamp, sequenceNumber, "", "")
         MessageRef prev = prevTimestamp == null ? null : new MessageRef(prevTimestamp, prevSequenceNumber)
-        return new StreamMessageV30(msgId, prev, StreamMessage.ContentType.CONTENT_TYPE_JSON, [hello: "world"], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+        return new StreamMessageV31(msgId, prev, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [hello: "world"], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
     }
 
     void "subscribe() sends SubscribeRequest and 1 ResendLastRequest after SubscribeResponse if answer received"() {

--- a/src/test/groovy/com/streamr/client/protocol/BroadcastMessageAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/BroadcastMessageAdapterSpec.groovy
@@ -4,7 +4,7 @@ import com.squareup.moshi.JsonReader
 import com.streamr.client.protocol.control_layer.BroadcastMessage
 import com.streamr.client.protocol.control_layer.BroadcastMessageAdapter
 import com.streamr.client.protocol.message_layer.StreamMessage
-import com.streamr.client.protocol.message_layer.StreamMessageV30
+import com.streamr.client.protocol.message_layer.StreamMessageV31
 import okio.Buffer
 import spock.lang.Specification
 
@@ -33,7 +33,7 @@ class BroadcastMessageAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
 		String json = '[1,0,'+msgJson+']'
 
 		when:
@@ -44,11 +44,11 @@ class BroadcastMessageAdapterSpec extends Specification {
 	}
 
 	void "toJson"() {
-		StreamMessageV30 msg = new StreamMessageV30(
+		StreamMessageV31 msg = new StreamMessageV31(
 				"7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId", "1", 1528228170000L, 0,
-				StreamMessage.ContentType.CONTENT_TYPE_JSON, '{"hello":"world"}', StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
+				StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, '{"hello":"world"}', StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
 		BroadcastMessage broadcastMessage = new BroadcastMessage(msg)
-		String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
 
 		when:
 		adapter.toJson(buffer, broadcastMessage)

--- a/src/test/groovy/com/streamr/client/protocol/ControlMessageAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ControlMessageAdapterSpec.groovy
@@ -36,7 +36,7 @@ class ControlMessageAdapterSpec extends Specification {
     }
 
     def "BroadcastMessage"() {
-        String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+        String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
         String json = '[1,0,'+msgJson+']'
         when:
         ControlMessage msg = fromJson(adapter, json)
@@ -45,7 +45,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "UnicastMessage"() {
-        String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+        String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
         String json = '[1,1,"subId",'+msgJson+']'
         when:
         ControlMessage msg = fromJson(adapter, json)
@@ -102,7 +102,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "PublishRequest"() {
-        String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+        String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
         String json = '[1,8,'+msgJson+',"sessionToken"]'
         when:
         ControlMessage msg = fromJson(adapter, json)

--- a/src/test/groovy/com/streamr/client/protocol/PublishRequestAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/PublishRequestAdapterSpec.groovy
@@ -4,7 +4,7 @@ import com.squareup.moshi.JsonReader
 import com.streamr.client.protocol.control_layer.PublishRequest
 import com.streamr.client.protocol.control_layer.PublishRequestAdapter
 import com.streamr.client.protocol.message_layer.StreamMessage
-import com.streamr.client.protocol.message_layer.StreamMessageV30
+import com.streamr.client.protocol.message_layer.StreamMessageV31
 import okio.Buffer
 import spock.lang.Specification
 
@@ -33,7 +33,7 @@ class PublishRequestAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
 		String json = '[1,8,'+msgJson+',"sessionToken"]'
 
 		when:
@@ -45,7 +45,7 @@ class PublishRequestAdapterSpec extends Specification {
 	}
 
 	void "fromJson (null session token)"() {
-		String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
 		String json = '[1,8,'+msgJson+',null]'
 
 		when:
@@ -57,11 +57,11 @@ class PublishRequestAdapterSpec extends Specification {
 	}
 
 	void "toJson"() {
-		StreamMessageV30 msg = new StreamMessageV30(
+		StreamMessageV31 msg = new StreamMessageV31(
 				"7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId", "1", 1528228170000L, 0,
-				StreamMessage.ContentType.CONTENT_TYPE_JSON, '{"hello":"world"}', StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
+				StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, '{"hello":"world"}', StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
 		PublishRequest request = new PublishRequest(msg, "sessionToken")
-		String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
 
 		when:
 		adapter.toJson(buffer, request)

--- a/src/test/groovy/com/streamr/client/protocol/StreamMessageV30AdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/StreamMessageV30AdapterSpec.groovy
@@ -6,8 +6,6 @@ import com.streamr.client.protocol.message_layer.MessageID
 import com.streamr.client.protocol.message_layer.MessageRef
 import com.streamr.client.protocol.message_layer.StreamMessage
 import com.streamr.client.protocol.message_layer.StreamMessage.ContentType
-import com.streamr.client.protocol.message_layer.StreamMessageV29
-import com.streamr.client.protocol.message_layer.StreamMessageV29Adapter
 import com.streamr.client.protocol.message_layer.StreamMessageV30
 import com.streamr.client.protocol.message_layer.StreamMessageV30Adapter
 import okio.Buffer

--- a/src/test/groovy/com/streamr/client/protocol/StreamMessageV31AdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/StreamMessageV31AdapterSpec.groovy
@@ -1,0 +1,221 @@
+package com.streamr.client.protocol
+
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.streamr.client.exceptions.ContentTypeNotParsableException
+import com.streamr.client.exceptions.EncryptedContentNotParsableException
+import com.streamr.client.protocol.message_layer.*
+import com.streamr.client.protocol.message_layer.StreamMessage.ContentType
+import com.streamr.client.protocol.message_layer.StreamMessage.EncryptionType
+import okio.Buffer
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+
+class StreamMessageV31AdapterSpec extends Specification {
+	StreamMessageV31Adapter adapter
+
+	void setup() {
+		adapter = new StreamMessageV31Adapter()
+	}
+
+	private static JsonReader toReader(String json) {
+		return JsonReader.of(new Buffer().writeString(json, Charset.forName("UTF-8")))
+	}
+
+	private static String msgToJson(StreamMessageV31Adapter adapter, StreamMessageV31 msg) {
+		Buffer buffer = new Buffer()
+		JsonWriter writer = JsonWriter.of(buffer)
+		writer.beginArray()
+		writer.value(msg.getVersion())
+		adapter.toJson(writer, msg)
+		writer.endArray()
+		return buffer.readUtf8()
+	}
+
+	private static StreamMessageV31 fromJsonToMsg(StreamMessageV31Adapter adapter, String json) {
+		JsonReader reader = toReader(json)
+		reader.beginArray()
+		reader.nextInt()
+		StreamMessageV31 msg = adapter.fromJson(reader)
+		reader.endArray()
+		return msg
+	}
+
+	void "toJson"() {
+		String serializedContent = '{"desi":"2","dir":"1","oper":40,"veh":222,"tst":"2018-06-05T19:49:33Z","tsi":1528228173,"spd":3.6,"hdg":69,"lat":60.192258,"long":24.928701,"acc":-0.59,"dl":-248,"odo":5134,"drst":0,"oday":"2018-06-05","jrn":885,"line":30,"start":"22:23"}'
+		String expectedJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
+		when:
+		StreamMessageV31 msg = new StreamMessageV31("7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId", "1", 1528228170000L, 0, ContentType.CONTENT_TYPE_JSON, EncryptionType.NONE, serializedContent, StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
+
+		then:
+		msgToJson(adapter, msg) == expectedJson
+	}
+
+	void "toJson (constructor with content map)"() {
+		Map content = ["desi":"2","dir":"1","oper":40,"veh":222,"tst":"2018-06-05T19:49:33Z","tsi":1528228173,"spd":3.6,"hdg":69,"lat":60.192258,"long":24.928701,"acc":-0.59,"dl":-248,"odo":5134,"drst":0,"oday":"2018-06-05","jrn":885,"line":30,"start":"22:23"]
+		String expectedJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,1,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
+		when:
+		StreamMessageV31 msg = new StreamMessageV31("7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId", "1", 1528228170000L, 0, ContentType.CONTENT_TYPE_JSON, EncryptionType.RSA, content, StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
+
+		then:
+		msgToJson(adapter, msg) == expectedJson
+	}
+
+	void "toJson with no signature"() {
+		String serializedContent = '{"desi":"2","dir":"1","oper":40,"veh":222,"tst":"2018-06-05T19:49:33Z","tsi":1528228173,"spd":3.6,"hdg":69,"lat":60.192258,"long":24.928701,"acc":-0.59,"dl":-248,"odo":5134,"drst":0,"oday":"2018-06-05","jrn":885,"line":30,"start":"22:23"}'
+		String expectedJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,2,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",0,null]"
+
+		when:
+		StreamMessageV31 msg = new StreamMessageV31("7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId", "1", 1528228170000L, 0, ContentType.CONTENT_TYPE_JSON, EncryptionType.AES, serializedContent, StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+
+		then:
+		msgToJson(adapter, msg) == expectedJson
+	}
+
+	void "toJson with null previous message ref"() {
+		String serializedContent = '{"desi":"2","dir":"1","oper":40,"veh":222,"tst":"2018-06-05T19:49:33Z","tsi":1528228173,"spd":3.6,"hdg":69,"lat":60.192258,"long":24.928701,"acc":-0.59,"dl":-248,"odo":5134,"drst":0,"oday":"2018-06-05","jrn":885,"line":30,"start":"22:23"}'
+		String expectedJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,27,3,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",0,null]"
+
+		when:
+		StreamMessageV31 msg = new StreamMessageV31("7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId", "1", (Long) null, 0, ContentType.CONTENT_TYPE_JSON, EncryptionType.NEW_KEY_AND_AES, serializedContent, StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+
+		then:
+		msgToJson(adapter, msg) == expectedJson
+	}
+
+	void "toJson with empty content"() {
+		String serializedContent = ""
+		String expectedJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"$serializedContent\",0,null]"
+
+		when:
+		MessageID messageID = new MessageID("7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId","1")
+		MessageRef previousMessageRef = new MessageRef(1528228170000L, 0)
+		StreamMessageV31 msg = new StreamMessageV31(messageID, previousMessageRef, ContentType.CONTENT_TYPE_JSON, EncryptionType.NONE, serializedContent, StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+
+		then:
+		msgToJson(adapter, msg) == expectedJson
+	}
+
+	void "fromJson"() {
+		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
+
+		when:
+		StreamMessageV31 msg = fromJsonToMsg(adapter, json)
+
+		then:
+		msg.getStreamId() == "7wa7APtlTq6EC5iTCBy6dw"
+		msg.getStreamPartition() == 0
+		msg.getTimestamp() == 1528228173462L
+		msg.getTimestampAsDate() == new Date(1528228173462L)
+		msg.getSequenceNumber() == 0
+		msg.getPublisherId() == "publisherId"
+		msg.getMsgChainId() == "1"
+		msg.getPreviousMessageRef().getTimestamp() == 1528228170000L
+		msg.getPreviousMessageRef().getTimestampAsDate() == new Date(1528228170000L)
+		msg.getPreviousMessageRef().getSequenceNumber() == 0
+		msg.getContentType() == ContentType.CONTENT_TYPE_JSON
+		msg.getEncryptionType() == EncryptionType.NONE
+		msg.getContent() instanceof Map
+		msg.getContent().desi == "2"
+		msg.getSignatureType() == StreamMessage.SignatureType.SIGNATURE_TYPE_ETH
+		msg.getSignature() == "signature"
+	}
+
+	void "fromJson with previousMessageRef null"() {
+		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
+
+		when:
+		StreamMessageV31 msg = fromJsonToMsg(adapter, json)
+
+		then:
+		msg.toJson() == json
+		msg.getStreamId() == "7wa7APtlTq6EC5iTCBy6dw"
+		msg.getStreamPartition() == 0
+		msg.getTimestamp() == 1528228173462L
+		msg.getTimestampAsDate() == new Date(1528228173462L)
+		msg.getSequenceNumber() == 0
+		msg.getPublisherId() == "publisherId"
+		msg.getMsgChainId() == "1"
+		msg.getPreviousMessageRef() == null
+		msg.getContentType() == ContentType.CONTENT_TYPE_JSON
+		msg.getEncryptionType() == EncryptionType.NONE
+		msg.getContent() instanceof Map
+		msg.getContent().desi == "2"
+		msg.getSignatureType() == StreamMessage.SignatureType.SIGNATURE_TYPE_ETH
+		msg.getSignature() == "signature"
+	}
+
+	void "fromJson with no signature"() {
+		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",0,null]"
+
+		when:
+		StreamMessageV31 msg = fromJsonToMsg(adapter, json)
+
+		then:
+		msg.toJson() == json
+		msg.getStreamId() == "7wa7APtlTq6EC5iTCBy6dw"
+		msg.getStreamPartition() == 0
+		msg.getTimestamp() == 1528228173462L
+		msg.getTimestampAsDate() == new Date(1528228173462L)
+		msg.getSequenceNumber() == 0
+		msg.getPublisherId() == "publisherId"
+		msg.getMsgChainId() == "1"
+		msg.getPreviousMessageRef() == null
+		msg.getContentType() == ContentType.CONTENT_TYPE_JSON
+		msg.getEncryptionType() == EncryptionType.NONE
+		msg.getContent() instanceof Map
+		msg.getContent().desi == "2"
+		msg.getSignatureType() == StreamMessage.SignatureType.SIGNATURE_TYPE_NONE
+	}
+
+	void "fromJson() with content types other than JSON"() {
+		String json1 = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,28,2,\"some group key request\",0,null]"
+		String json2 = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,29,2,\"some group key\",0,null]"
+		String json3 = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,30,2,\"some new group key\",0,null]"
+
+		when:
+		StreamMessageV31 msg1 = fromJsonToMsg(adapter, json1)
+		msg1.getContent()
+		then:
+		thrown ContentTypeNotParsableException
+		msg1.toJson() == json1
+		msg1.getContentType() == ContentType.GROUP_KEY_REQUEST
+		msg1.getSerializedContent() == "some group key request"
+		when:
+		StreamMessageV31 msg2 = fromJsonToMsg(adapter, json2)
+		msg2.getContent()
+		then:
+		thrown ContentTypeNotParsableException
+		msg2.toJson() == json2
+		msg2.getContentType() == ContentType.GROUP_KEY_RESPONSE_SIMPLE
+		msg2.getSerializedContent() == "some group key"
+		when:
+		StreamMessageV31 msg3 = fromJsonToMsg(adapter, json3)
+		msg3.getContent()
+		then:
+		thrown ContentTypeNotParsableException
+		msg3.toJson() == json3
+		msg3.getContentType() == ContentType.GROUP_KEY_RESET_SIMPLE
+		msg3.getSerializedContent() == "some new group key"
+	}
+
+	void "getContent() throws if encrypted"() {
+		StreamMessageV31 msg1 = new StreamMessageV31("", 0, 0L, 0, "", "", 0L, 0, ContentType.CONTENT_TYPE_JSON, EncryptionType.RSA, "encrypted content", StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+		StreamMessageV31 msg2 = new StreamMessageV31("", 0, 0L, 0, "", "", 0L, 0, ContentType.CONTENT_TYPE_JSON, EncryptionType.AES, "encrypted content", StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+		StreamMessageV31 msg3 = new StreamMessageV31("", 0, 0L, 0, "", "", 0L, 0, ContentType.CONTENT_TYPE_JSON, EncryptionType.NEW_KEY_AND_AES, "encrypted content", StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+
+		when:
+		msg1.getContent()
+		then:
+		thrown EncryptedContentNotParsableException
+		when:
+		msg2.getContent()
+		then:
+		thrown EncryptedContentNotParsableException
+		when:
+		msg3.getContent()
+		then:
+		thrown EncryptedContentNotParsableException
+	}
+}

--- a/src/test/groovy/com/streamr/client/protocol/UnicastMessageAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/UnicastMessageAdapterSpec.groovy
@@ -4,7 +4,7 @@ import com.squareup.moshi.JsonReader
 import com.streamr.client.protocol.control_layer.UnicastMessage
 import com.streamr.client.protocol.control_layer.UnicastMessageAdapter
 import com.streamr.client.protocol.message_layer.StreamMessage
-import com.streamr.client.protocol.message_layer.StreamMessageV30
+import com.streamr.client.protocol.message_layer.StreamMessageV31
 import okio.Buffer
 import spock.lang.Specification
 
@@ -33,7 +33,7 @@ class UnicastMessageAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
 		String json = '[1,1,"subId",'+msgJson+']'
 
 		when:
@@ -45,11 +45,11 @@ class UnicastMessageAdapterSpec extends Specification {
 	}
 
 	void "toJson"() {
-		StreamMessageV30 msg = new StreamMessageV30(
+		StreamMessageV31 msg = new StreamMessageV31(
 				"7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId", "1", 1528228170000L, 0,
-				StreamMessage.ContentType.CONTENT_TYPE_JSON, '{"hello":"world"}', StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
+				StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, '{"hello":"world"}', StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
 		UnicastMessage unicastMessage = new UnicastMessage("subId", msg)
-		String msgJson = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
 
 		when:
 		adapter.toJson(buffer, unicastMessage)

--- a/src/test/groovy/com/streamr/client/utils/MessageCreationUtilSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/MessageCreationUtilSpec.groovy
@@ -141,7 +141,7 @@ class MessageCreationUtilSpec extends Specification {
 
     void "creates encrypted messages when key defined in constructor"() {
         String key = genKey(32)
-        MessageCreationUtil util = new MessageCreationUtil("publisherId", null, key)
+        MessageCreationUtil util = new MessageCreationUtil("publisherId", null, [(stream.id): key])
         when:
         StreamMessageV31 msg = (StreamMessageV31) util.createStreamMessage(stream, message, new Date(), null)
         then:
@@ -152,7 +152,7 @@ class MessageCreationUtilSpec extends Specification {
     void "throws if the key is not 256 bits long"() {
         String key = genKey(16)
         when:
-        new MessageCreationUtil("publisherId", null, key)
+        new MessageCreationUtil("publisherId", null, [(stream.id): key])
         then:
         thrown InvalidGroupKeyException
 

--- a/src/test/groovy/com/streamr/client/utils/SigningUtilSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/SigningUtilSpec.groovy
@@ -3,7 +3,7 @@ package com.streamr.client.utils
 import com.streamr.client.protocol.message_layer.MessageID
 import com.streamr.client.protocol.message_layer.MessageRef
 import com.streamr.client.protocol.message_layer.StreamMessage
-import com.streamr.client.protocol.message_layer.StreamMessageV30
+import com.streamr.client.protocol.message_layer.StreamMessageV31
 import org.apache.commons.codec.binary.Hex
 import org.ethereum.crypto.ECKey
 import spock.lang.Specification
@@ -34,7 +34,7 @@ class SigningUtilSpec extends Specification {
     }
 
     void "should correctly sign a StreamMessage with null previous ref"() {
-        StreamMessage msg = new StreamMessageV30(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+        StreamMessage msg = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
         String expectedPayload = "streamId04252353150publisherIdmsgChainId"+'{"foo":"bar"}'
         when:
         signingUtil.signStreamMessage(msg)
@@ -44,7 +44,7 @@ class SigningUtilSpec extends Specification {
     }
 
     void "should correctly sign a StreamMessage with non-null previous ref"() {
-        StreamMessage msg = new StreamMessageV30(msgId, new MessageRef(100, 1), StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+        StreamMessage msg = new StreamMessageV31(msgId, new MessageRef(100, 1), StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
         String expectedPayload = "streamId04252353150publisherIdmsgChainId1001"+'{"foo":"bar"}'
         when:
         signingUtil.signStreamMessage(msg)
@@ -55,14 +55,14 @@ class SigningUtilSpec extends Specification {
 
     void "returns false if no signature"() {
         when:
-        StreamMessage msg = new StreamMessageV30(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
+        StreamMessage msg = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
         then:
         !SigningUtil.hasValidSignature(msg, ["publisherId"].toSet())
     }
 
     void "returns false if wrong signature"() {
         when:
-        StreamMessage msg = new StreamMessageV30(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'],
+        StreamMessage msg = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
                 StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "0x787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b")
         then:
         !SigningUtil.hasValidSignature(msg, ["publisherId"].toSet())
@@ -70,7 +70,7 @@ class SigningUtilSpec extends Specification {
 
     void "returns true if correct signature"() {
         MessageID msgId = new MessageID("streamId", 0, 425235315L, 0L, address, "msgChainId")
-        StreamMessage msg = new StreamMessageV30(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'],
+        StreamMessage msg = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
                 StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
         when:
         signingUtil.signStreamMessage(msg)
@@ -80,7 +80,7 @@ class SigningUtilSpec extends Specification {
 
     void "returns false if correct signature but not from a trusted publisher"() {
         MessageID msgId = new MessageID("streamId", 0, 425235315L, 0L, address, "msgChainId")
-        StreamMessage msg = new StreamMessageV30(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'],
+        StreamMessage msg = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
                 StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
         when:
         signingUtil.signStreamMessage(msg)

--- a/src/test/groovy/com/streamr/client/utils/SubscribedStreamsUtilSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/SubscribedStreamsUtilSpec.groovy
@@ -3,7 +3,7 @@ package com.streamr.client.utils
 import com.streamr.client.exceptions.InvalidSignatureException
 import com.streamr.client.protocol.message_layer.MessageID
 import com.streamr.client.protocol.message_layer.StreamMessage
-import com.streamr.client.protocol.message_layer.StreamMessageV30
+import com.streamr.client.protocol.message_layer.StreamMessageV31
 import com.streamr.client.rest.Stream
 import spock.lang.Specification
 import com.streamr.client.options.SigningOptions.SignatureVerificationPolicy
@@ -13,14 +13,14 @@ class SubscribedStreamsUtilSpec extends Specification {
     MessageID msgId = new MessageID("streamId", 0, 425235315L, 0L, "publisherId", "msgChainId")
 
     // The signature of this message is invalid but still in a correct format
-    StreamMessage msgInvalid = new StreamMessageV30(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'],
+    StreamMessage msgInvalid = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
             StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, signature)
 
     // By checking that this message is verified without throwing, we ensure that the SigningUtil is not called because the signature is not in the correct form
-    StreamMessage msgWrongFormat = new StreamMessageV30(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'],
+    StreamMessage msgWrongFormat = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
             StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "wrong-signature")
 
-    StreamMessage msgUnsigned = new StreamMessageV30(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, [foo: 'bar'],
+    StreamMessage msgUnsigned = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
             StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
 
     List<String> publishers = ["publisherId"]


### PR DESCRIPTION
This PR contains:
- StreamMessageV31 and its adapter.
- Encryption and decryption when publishing and subscribing (using StreamMessageV31)

Since the backend doesn't support v31 yet, the integration tests fail. So IMO the next steps should the following:
1) review
2) publish this PR to maven as a snapshot
3) use the snapshot in `engine-and-editor` and `cloud-broker`
4) use the v31 JS protocol in `data-api`
5) make the existing the integration tests pass
6) add integration tests specific to encryption
7) merge