### PR TITLE
use second endpoint when cache miss

### DIFF
--- a/src/integrationTest/groovy/com/streamr/client/StreamEndpointsSpec.groovy
+++ b/src/integrationTest/groovy/com/streamr/client/StreamEndpointsSpec.groovy
@@ -178,6 +178,17 @@ class StreamEndpointsSpec extends StreamrIntegrationSpecification {
         publishers == [client.getPublisherId()]
     }
 
+    void "isPublisher()"() {
+        Stream proto = new Stream(generateResourceName(), "This stream was created from an integration test")
+        Stream createdResult = client.createStream(proto)
+        when:
+        boolean isValid1 = client.isPublisher(createdResult.id, client.getPublisherId())
+        boolean isValid2 = client.isPublisher(createdResult.id, "wrong-address")
+        then:
+        isValid1
+        !isValid2
+    }
+
     void "not same token used after logout()"() {
         StreamrClient apiKeyClient = createClientWithApiKey("tester1-api-key")
         when:

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -65,6 +65,12 @@ public class StreamrClient extends StreamrRESTClient {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+        }, (s, p) -> {
+            try {
+                return isPublisher(s, p);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }, options.getSigningOptions().getVerifySignatures());
 
         if (options.getAuthenticationMethod() instanceof ApiKeyAuthenticationMethod) {

--- a/src/main/java/com/streamr/client/StreamrRESTClient.java
+++ b/src/main/java/com/streamr/client/StreamrRESTClient.java
@@ -151,6 +151,16 @@ public abstract class StreamrRESTClient extends AbstractStreamrClient {
         return get(url, publishersJsonAdapter).getAddresses();
     }
 
+    public boolean isPublisher(String streamId, String ethAddress) throws IOException {
+        HttpUrl url = HttpUrl.parse(options.getRestApiUrl() + "/streams/" + streamId + "/publisher/" + ethAddress);
+        try {
+            get(url, null);
+            return true;
+        } catch (ResourceNotFoundException e) {
+            return false;
+        }
+    }
+
     public void logout() throws IOException {
         HttpUrl url = HttpUrl.parse(options.getRestApiUrl() + "/logout");
         post(url, "", null, false);

--- a/src/main/java/com/streamr/client/exceptions/InvalidSignatureException.java
+++ b/src/main/java/com/streamr/client/exceptions/InvalidSignatureException.java
@@ -3,7 +3,16 @@ package com.streamr.client.exceptions;
 import com.streamr.client.protocol.message_layer.StreamMessage;
 
 public class InvalidSignatureException extends RuntimeException {
-    public InvalidSignatureException(StreamMessage msg) {
+    private boolean failedBecauseInvalidPublisher;
+    public InvalidSignatureException(StreamMessage msg, Boolean validPublisher) {
         super("Invalid signature for message: "+msg.toJson());
+        this.failedBecauseInvalidPublisher = validPublisher == null ? false : !validPublisher;
+    }
+    public InvalidSignatureException(StreamMessage msg) {
+        this(msg, null);
+    }
+
+    public boolean failedBecauseInvalidPublisher() {
+        return failedBecauseInvalidPublisher;
     }
 }

--- a/src/main/java/com/streamr/client/exceptions/InvalidSignatureException.java
+++ b/src/main/java/com/streamr/client/exceptions/InvalidSignatureException.java
@@ -8,9 +8,6 @@ public class InvalidSignatureException extends RuntimeException {
         super("Invalid signature for message: "+msg.toJson());
         this.failedBecauseInvalidPublisher = validPublisher == null ? false : !validPublisher;
     }
-    public InvalidSignatureException(StreamMessage msg) {
-        this(msg, null);
-    }
 
     public boolean failedBecauseInvalidPublisher() {
         return failedBecauseInvalidPublisher;

--- a/src/main/java/com/streamr/client/utils/SignatureVerificationResult.java
+++ b/src/main/java/com/streamr/client/utils/SignatureVerificationResult.java
@@ -1,0 +1,31 @@
+package com.streamr.client.utils;
+
+public class SignatureVerificationResult {
+    private boolean correct;
+    private Boolean validPublisher;
+
+    private SignatureVerificationResult(boolean correct, Boolean validPublisher) {
+        this.correct = correct;
+        this.validPublisher = validPublisher;
+    }
+
+    public static SignatureVerificationResult fromBoolean(boolean correct) {
+        return new SignatureVerificationResult(correct, null);
+    }
+
+    public static SignatureVerificationResult withValidPublisher(boolean isValidSignature) {
+        return new SignatureVerificationResult(isValidSignature, true);
+    }
+
+    public static SignatureVerificationResult invalidPublisher() {
+        return new SignatureVerificationResult(false, false);
+    }
+
+    public boolean isCorrect() {
+        return correct;
+    }
+
+    public Boolean isValidPublisher() {
+        return validPublisher;
+    }
+}

--- a/src/main/java/com/streamr/client/utils/SigningUtil.java
+++ b/src/main/java/com/streamr/client/utils/SigningUtil.java
@@ -43,14 +43,13 @@ public class SigningUtil {
                 new byte[]{sig.v}));
     }
 
-    public static boolean hasValidSignature(StreamMessage msg, Set<String> publishers) {
+    public static boolean hasValidSignature(StreamMessage msg) {
         if (msg.getSignature() == null) {
             return false;
         }
         String payload = getPayloadToSignOrVerify(msg, msg.getSignatureType());
         try {
-            boolean valid = verify(payload, msg.getSignature(), msg.getPublisherId());
-            return valid && publishers.contains(msg.getPublisherId());
+            return verify(payload, msg.getSignature(), msg.getPublisherId());
         } catch (SignatureException | DecoderException e) {
             throw new SignatureFailedException(e.getMessage());
         }

--- a/src/test/groovy/com/streamr/client/utils/SigningUtilSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/SigningUtilSpec.groovy
@@ -57,7 +57,7 @@ class SigningUtilSpec extends Specification {
         when:
         StreamMessage msg = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'], StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
         then:
-        !SigningUtil.hasValidSignature(msg, ["publisherId"].toSet())
+        !SigningUtil.hasValidSignature(msg)
     }
 
     void "returns false if wrong signature"() {
@@ -65,7 +65,7 @@ class SigningUtilSpec extends Specification {
         StreamMessage msg = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
                 StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "0x787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b")
         then:
-        !SigningUtil.hasValidSignature(msg, ["publisherId"].toSet())
+        !SigningUtil.hasValidSignature(msg)
     }
 
     void "returns true if correct signature"() {
@@ -75,16 +75,6 @@ class SigningUtilSpec extends Specification {
         when:
         signingUtil.signStreamMessage(msg)
         then:
-        SigningUtil.hasValidSignature(msg, [address].toSet())
-    }
-
-    void "returns false if correct signature but not from a trusted publisher"() {
-        MessageID msgId = new MessageID("streamId", 0, 425235315L, 0L, address, "msgChainId")
-        StreamMessage msg = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
-                StreamMessage.SignatureType.SIGNATURE_TYPE_NONE, null)
-        when:
-        signingUtil.signStreamMessage(msg)
-        then:
-        !SigningUtil.hasValidSignature(msg, ["trustedPublisher"].toSet())
+        SigningUtil.hasValidSignature(msg)
     }
 }

--- a/src/test/groovy/com/streamr/client/utils/SubscribedStreamsUtilSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/SubscribedStreamsUtilSpec.groovy
@@ -11,9 +11,15 @@ import com.streamr.client.options.SigningOptions.SignatureVerificationPolicy
 class SubscribedStreamsUtilSpec extends Specification {
     String signature = "0x787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b"
     MessageID msgId = new MessageID("streamId", 0, 425235315L, 0L, "publisherId", "msgChainId")
+    MessageID msgId2 = new MessageID("streamId", 0, 425235315L, 0L, "publisherId2", "msgChainId")
+    MessageID msgId3 = new MessageID("streamId", 0, 425235315L, 0L, "publisherId3", "msgChainId")
 
     // The signature of this message is invalid but still in a correct format
     StreamMessage msgInvalid = new StreamMessageV31(msgId, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
+            StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, signature)
+    StreamMessage msgInvalid2 = new StreamMessageV31(msgId2, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
+            StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, signature)
+    StreamMessage msgInvalid3 = new StreamMessageV31(msgId3, null, StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, [foo: 'bar'],
             StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, signature)
 
     // By checking that this message is verified without throwing, we ensure that the SigningUtil is not called because the signature is not in the correct form
@@ -26,7 +32,8 @@ class SubscribedStreamsUtilSpec extends Specification {
     List<String> publishers = ["publisherId"]
     Stream stream = new Stream("test-stream", "")
     SubscribedStreamsUtil getUtil(SignatureVerificationPolicy verifySignatures) {
-        return new SubscribedStreamsUtil({ String id -> stream }, { String id -> publishers }, verifySignatures)
+        return new SubscribedStreamsUtil({ String id -> stream }, { String id -> publishers },
+                { String s, String p -> p == "publisherId2"}, verifySignatures)
     }
 
     void "should return true without verifying if policy is 'never' for both signed and unsigned messages"() {
@@ -43,7 +50,8 @@ class SubscribedStreamsUtilSpec extends Specification {
         when:
         util.verifyStreamMessage(msgUnsigned)
         then:
-        thrown(InvalidSignatureException)
+        InvalidSignatureException e = thrown(InvalidSignatureException)
+        !e.failedBecauseInvalidPublisher()
     }
 
     void "should verify if policy is 'always'"() {
@@ -51,7 +59,8 @@ class SubscribedStreamsUtilSpec extends Specification {
         when:
         util.verifyStreamMessage(msgInvalid)
         then:
-        thrown(InvalidSignatureException)
+        InvalidSignatureException e = thrown(InvalidSignatureException)
+        !e.failedBecauseInvalidPublisher()
     }
 
     void "should verify if policy is 'auto' and signature is present, even if stream does not require signed data"() {
@@ -59,7 +68,8 @@ class SubscribedStreamsUtilSpec extends Specification {
         when:
         util.verifyStreamMessage(msgInvalid)
         then:
-        thrown(InvalidSignatureException)
+        InvalidSignatureException e = thrown(InvalidSignatureException)
+        !e.failedBecauseInvalidPublisher()
     }
 
     void "should throw if policy is 'auto', signature is not present, and stream requires signed data"() {
@@ -68,7 +78,8 @@ class SubscribedStreamsUtilSpec extends Specification {
         when:
         util.verifyStreamMessage(msgUnsigned)
         then:
-        thrown(InvalidSignatureException)
+        InvalidSignatureException e = thrown(InvalidSignatureException)
+        !e.failedBecauseInvalidPublisher()
         stream.setRequireSignedData(false)
     }
 
@@ -78,5 +89,23 @@ class SubscribedStreamsUtilSpec extends Specification {
         util.verifyStreamMessage(msgUnsigned)
         then:
         notThrown(InvalidSignatureException)
+    }
+
+    void "should throw but not because the publisher is invalid (publisher not in initial cache)"() {
+        SubscribedStreamsUtil util = getUtil(SignatureVerificationPolicy.AUTO)
+        when:
+        util.verifyStreamMessage(msgInvalid2)
+        then:
+        InvalidSignatureException e = thrown(InvalidSignatureException)
+        !e.failedBecauseInvalidPublisher()
+    }
+
+    void "should throw because the publisher is invalid (publisher not in initial cache)"() {
+        SubscribedStreamsUtil util = getUtil(SignatureVerificationPolicy.AUTO)
+        when:
+        util.verifyStreamMessage(msgInvalid3)
+        then:
+        InvalidSignatureException e = thrown(InvalidSignatureException)
+        e.failedBecauseInvalidPublisher()
     }
 }


### PR DESCRIPTION
Same feature that has already been done in the Javascript client:
- cache both positive and negative results instead of a set of strings (publishers)
- use `streams/id/publisher/address` when cache miss, update the cache and return result