### PR TITLE
Enforce query string on ws endpoint

### DIFF
--- a/src/main/java/com/streamr/client/options/StreamrClientOptions.java
+++ b/src/main/java/com/streamr/client/options/StreamrClientOptions.java
@@ -64,7 +64,7 @@ public class StreamrClientOptions {
     }
 
     public void setWebsocketApiUrl(String websocketApiUrl) {
-        this.websocketApiUrl = websocketApiUrl;
+        this.websocketApiUrl = addMissingQueryString(websocketApiUrl);
     }
 
     public String getRestApiUrl() {

--- a/src/test/groovy/com/streamr/client/StreamrClientOptionsSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientOptionsSpec.groovy
@@ -32,4 +32,31 @@ class StreamrClientOptionsSpec extends Specification {
         then:
         options.getWebsocketApiUrl() == expectedUrl
     }
+    void "adds missing query string (in set method)"() {
+        String url = "some-url"
+        String expectedUrl = url + "?controlLayerVersion=" + ControlMessage.LATEST_VERSION + "&messageLayerVersion=" + StreamMessage.LATEST_VERSION
+        StreamrClientOptions options = new StreamrClientOptions(null, SigningOptions.getDefault(), EncryptionOptions.getDefault(), "", "")
+        when:
+        options.setWebsocketApiUrl(url)
+        then:
+        options.getWebsocketApiUrl() == expectedUrl
+    }
+    void "adds missing control layer version param (in set method)"() {
+        String url = "some-url?messageLayerVersion=31"
+        String expectedUrl = url + "&controlLayerVersion=" + ControlMessage.LATEST_VERSION
+        StreamrClientOptions options = new StreamrClientOptions(null, SigningOptions.getDefault(), EncryptionOptions.getDefault(), "", "")
+        when:
+        options.setWebsocketApiUrl(url)
+        then:
+        options.getWebsocketApiUrl() == expectedUrl
+    }
+    void "adds missing message layer version param (in set method)"() {
+        String url = "some-url?controlLayerVersion=1"
+        String expectedUrl = url + "&messageLayerVersion=" + StreamMessage.LATEST_VERSION
+        StreamrClientOptions options = new StreamrClientOptions(null, SigningOptions.getDefault(), EncryptionOptions.getDefault(), "", "")
+        when:
+        options.setWebsocketApiUrl(url)
+        then:
+        options.getWebsocketApiUrl() == expectedUrl
+    }
 }


### PR DESCRIPTION
Noticed a small problem with using the library. Made a quick fix via GitHub file editor, so **this is untested**. Could you @mthambipillai pick it up from here: verify it's working and include it in the next release, thanks.