### PR TITLE
Net 57 protocol delete

### DIFF
--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -473,7 +473,12 @@ public class StreamrClient extends StreamrRESTClient {
             throw new UnexpectedMessageException(deleteResponse);
         }
         String logMsg = deleteResponse.getStatus() ? "Successfully deleted " : "Failed to delete ";
-        log.info(logMsg + request.getDeletionMessage());
+        logMsg += request.getDeletionMessage();
+        if (deleteResponse.getStatus()) {
+            log.info(logMsg);
+        } else {
+            log.warn(logMsg);
+        }
         onGoingDeleteRequests.remove(deleteResponse.getRequestId());
     }
 }

--- a/src/main/java/com/streamr/client/exceptions/UnexpectedMessageException.java
+++ b/src/main/java/com/streamr/client/exceptions/UnexpectedMessageException.java
@@ -1,0 +1,9 @@
+package com.streamr.client.exceptions;
+
+import com.streamr.client.protocol.control_layer.ControlMessage;
+
+public class UnexpectedMessageException extends RuntimeException {
+    public UnexpectedMessageException(ControlMessage msg) {
+        super("Received unexpected control message: " + msg.toJson());
+    }
+}

--- a/src/main/java/com/streamr/client/protocol/control_layer/ControlMessageAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ControlMessageAdapter.java
@@ -28,6 +28,8 @@ public class ControlMessageAdapter extends JsonAdapter<ControlMessage> {
         adapters.put(ResendLastRequest.TYPE, new ResendLastRequestAdapter());
         adapters.put(ResendFromRequest.TYPE, new ResendFromRequestAdapter());
         adapters.put(ResendRangeRequest.TYPE, new ResendRangeRequestAdapter());
+        adapters.put(DeleteRequest.TYPE, new DeleteRequestAdapter());
+        adapters.put(DeleteResponse.TYPE, new DeleteResponseAdapter());
     }
 
     @Override

--- a/src/main/java/com/streamr/client/protocol/control_layer/DeleteRequest.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/DeleteRequest.java
@@ -1,17 +1,22 @@
 package com.streamr.client.protocol.control_layer;
 
+import java.util.Date;
+
 public class DeleteRequest extends ControlMessage {
     public static final int TYPE = 14;
 
     private final String streamId;
     private final int streamPartition;
+    // Used to link the received DeleteResponse to the DeleteRequest sent
+    private final String requestId;
     private final Long fromTimestamp;
     private final Long toTimestamp;
 
-    public DeleteRequest(String streamId, int streamPartition, Long fromTimestamp, Long toTimestamp) {
+    public DeleteRequest(String streamId, int streamPartition, String requestId, Long fromTimestamp, Long toTimestamp) {
         super(TYPE);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
+        this.requestId = requestId;
         this.fromTimestamp = fromTimestamp;
         this.toTimestamp = toTimestamp;
     }
@@ -24,11 +29,27 @@ public class DeleteRequest extends ControlMessage {
         return streamPartition;
     }
 
+    public String getRequestId() {
+        return requestId;
+    }
+
     public Long getFromTimestamp() {
         return fromTimestamp;
     }
 
     public Long getToTimestamp() {
         return toTimestamp;
+    }
+
+    public String getDeletionMessage() {
+        String msg;
+        if (fromTimestamp == null && toTimestamp == null) {
+            msg = "all data";
+        } else if (toTimestamp == null) {
+            msg = "data from " + new Date(fromTimestamp);
+        } else {
+            msg = "data between " + new Date(fromTimestamp) + " and " + new Date(toTimestamp);
+        }
+        return msg + " for stream id " + streamId + " and partition " + streamPartition;
     }
 }

--- a/src/main/java/com/streamr/client/protocol/control_layer/DeleteRequest.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/DeleteRequest.java
@@ -1,0 +1,34 @@
+package com.streamr.client.protocol.control_layer;
+
+public class DeleteRequest extends ControlMessage {
+    public static final int TYPE = 14;
+
+    private final String streamId;
+    private final int streamPartition;
+    private final Long fromTimestamp;
+    private final Long toTimestamp;
+
+    public DeleteRequest(String streamId, int streamPartition, Long fromTimestamp, Long toTimestamp) {
+        super(TYPE);
+        this.streamId = streamId;
+        this.streamPartition = streamPartition;
+        this.fromTimestamp = fromTimestamp;
+        this.toTimestamp = toTimestamp;
+    }
+
+    public String getStreamId() {
+        return streamId;
+    }
+
+    public int getStreamPartition() {
+        return streamPartition;
+    }
+
+    public Long getFromTimestamp() {
+        return fromTimestamp;
+    }
+
+    public Long getToTimestamp() {
+        return toTimestamp;
+    }
+}

--- a/src/main/java/com/streamr/client/protocol/control_layer/DeleteRequestAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/DeleteRequestAdapter.java
@@ -12,9 +12,10 @@ public class DeleteRequestAdapter extends ControlLayerAdapter<DeleteRequest> {
     public DeleteRequest fromJson(JsonReader reader) throws IOException {
         String streamId = reader.nextString();
         int streamPartition = reader.nextInt();
+        String requestId = reader.nextString();
         Long fromTimestamp = nullSafe(reader, JsonReader::nextLong);
         Long toTimestamp = nullSafe(reader, JsonReader::nextLong);
-        return new DeleteRequest(streamId, streamPartition, fromTimestamp, toTimestamp);
+        return new DeleteRequest(streamId, streamPartition, requestId, fromTimestamp, toTimestamp);
     }
 
     @Override
@@ -24,6 +25,7 @@ public class DeleteRequestAdapter extends ControlLayerAdapter<DeleteRequest> {
         writer.value(DeleteRequest.TYPE);
         writer.value(value.getStreamId());
         writer.value(value.getStreamPartition());
+        writer.value(value.getRequestId());
         writer.value(value.getFromTimestamp());
         writer.value(value.getToTimestamp());
         writer.endArray();

--- a/src/main/java/com/streamr/client/protocol/control_layer/DeleteRequestAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/DeleteRequestAdapter.java
@@ -1,0 +1,31 @@
+package com.streamr.client.protocol.control_layer;
+
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class DeleteRequestAdapter extends ControlLayerAdapter<DeleteRequest> {
+    @Nullable
+    @Override
+    public DeleteRequest fromJson(JsonReader reader) throws IOException {
+        String streamId = reader.nextString();
+        int streamPartition = reader.nextInt();
+        Long fromTimestamp = nullSafe(reader, JsonReader::nextLong);
+        Long toTimestamp = nullSafe(reader, JsonReader::nextLong);
+        return new DeleteRequest(streamId, streamPartition, fromTimestamp, toTimestamp);
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, @Nullable DeleteRequest value) throws IOException {
+        writer.beginArray();
+        writer.value(ControlMessage.LATEST_VERSION);
+        writer.value(DeleteRequest.TYPE);
+        writer.value(value.getStreamId());
+        writer.value(value.getStreamPartition());
+        writer.value(value.getFromTimestamp());
+        writer.value(value.getToTimestamp());
+        writer.endArray();
+    }
+}

--- a/src/main/java/com/streamr/client/protocol/control_layer/DeleteResponse.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/DeleteResponse.java
@@ -5,13 +5,16 @@ public class DeleteResponse extends ControlMessage {
 
     private final String streamId;
     private final int streamPartition;
+    // the same as the requestId of the DeleteRequest that corresponds to this DeleteResponse
+    private final String requestId;
     // true if the deletion was successful, false otherwise
     private final boolean status;
 
-    public DeleteResponse(String streamId, int streamPartition, boolean status) {
+    public DeleteResponse(String streamId, int streamPartition, String requestId, boolean status) {
         super(TYPE);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
+        this.requestId = requestId;
         this.status = status;
     }
 
@@ -21,6 +24,10 @@ public class DeleteResponse extends ControlMessage {
 
     public int getStreamPartition() {
         return streamPartition;
+    }
+
+    public String getRequestId() {
+        return requestId;
     }
 
     public boolean getStatus() {

--- a/src/main/java/com/streamr/client/protocol/control_layer/DeleteResponse.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/DeleteResponse.java
@@ -1,0 +1,29 @@
+package com.streamr.client.protocol.control_layer;
+
+public class DeleteResponse extends ControlMessage {
+    public static final int TYPE = 15;
+
+    private final String streamId;
+    private final int streamPartition;
+    // true if the deletion was successful, false otherwise
+    private final boolean status;
+
+    public DeleteResponse(String streamId, int streamPartition, boolean status) {
+        super(TYPE);
+        this.streamId = streamId;
+        this.streamPartition = streamPartition;
+        this.status = status;
+    }
+
+    public String getStreamId() {
+        return streamId;
+    }
+
+    public int getStreamPartition() {
+        return streamPartition;
+    }
+
+    public boolean getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/streamr/client/protocol/control_layer/DeleteResponseAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/DeleteResponseAdapter.java
@@ -1,0 +1,29 @@
+package com.streamr.client.protocol.control_layer;
+
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class DeleteResponseAdapter extends ControlLayerAdapter<DeleteResponse> {
+    @Nullable
+    @Override
+    public DeleteResponse fromJson(JsonReader reader) throws IOException {
+        String streamId = reader.nextString();
+        int streamPartition = reader.nextInt();
+        boolean status = reader.nextBoolean();
+        return new DeleteResponse(streamId, streamPartition, status);
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, @Nullable DeleteResponse value) throws IOException {
+        writer.beginArray();
+        writer.value(ControlMessage.LATEST_VERSION);
+        writer.value(DeleteResponse.TYPE);
+        writer.value(value.getStreamId());
+        writer.value(value.getStreamPartition());
+        writer.value(value.getStatus());
+        writer.endArray();
+    }
+}

--- a/src/main/java/com/streamr/client/protocol/control_layer/DeleteResponseAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/DeleteResponseAdapter.java
@@ -12,8 +12,9 @@ public class DeleteResponseAdapter extends ControlLayerAdapter<DeleteResponse> {
     public DeleteResponse fromJson(JsonReader reader) throws IOException {
         String streamId = reader.nextString();
         int streamPartition = reader.nextInt();
+        String requestId = reader.nextString();
         boolean status = reader.nextBoolean();
-        return new DeleteResponse(streamId, streamPartition, status);
+        return new DeleteResponse(streamId, streamPartition, requestId, status);
     }
 
     @Override
@@ -23,6 +24,7 @@ public class DeleteResponseAdapter extends ControlLayerAdapter<DeleteResponse> {
         writer.value(DeleteResponse.TYPE);
         writer.value(value.getStreamId());
         writer.value(value.getStreamPartition());
+        writer.value(value.getRequestId());
         writer.value(value.getStatus());
         writer.endArray();
     }

--- a/src/test/groovy/com/streamr/client/protocol/ControlMessageAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ControlMessageAdapterSpec.groovy
@@ -153,7 +153,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "DeleteRequest"() {
-        String json = '[1,14,"streamId",0,123,456]'
+        String json = '[1,14,"streamId",0,"requestId",123,456]'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:
@@ -161,7 +161,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "DeleteResponse"() {
-        String json = '[1,15,"streamId",0,false]'
+        String json = '[1,15,"streamId",0,"requestId",false]'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:

--- a/src/test/groovy/com/streamr/client/protocol/ControlMessageAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ControlMessageAdapterSpec.groovy
@@ -4,6 +4,8 @@ import com.squareup.moshi.JsonReader
 import com.streamr.client.protocol.control_layer.BroadcastMessage
 import com.streamr.client.protocol.control_layer.ControlMessage
 import com.streamr.client.protocol.control_layer.ControlMessageAdapter
+import com.streamr.client.protocol.control_layer.DeleteRequest
+import com.streamr.client.protocol.control_layer.DeleteResponse
 import com.streamr.client.protocol.control_layer.ErrorResponse
 import com.streamr.client.protocol.control_layer.PublishRequest
 import com.streamr.client.protocol.control_layer.ResendFromRequest
@@ -148,6 +150,22 @@ class ControlMessageAdapterSpec extends Specification {
         ControlMessage msg = fromJson(adapter, json)
         then:
         msg instanceof ResendRangeRequest
+        msg.toJson() == json
+    }
+    def "DeleteRequest"() {
+        String json = '[1,14,"streamId",0,123,456]'
+        when:
+        ControlMessage msg = fromJson(adapter, json)
+        then:
+        msg instanceof DeleteRequest
+        msg.toJson() == json
+    }
+    def "DeleteResponse"() {
+        String json = '[1,15,"streamId",0,false]'
+        when:
+        ControlMessage msg = fromJson(adapter, json)
+        then:
+        msg instanceof DeleteResponse
         msg.toJson() == json
     }
 }

--- a/src/test/groovy/com/streamr/client/protocol/DeleteRequestAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/DeleteRequestAdapterSpec.groovy
@@ -1,0 +1,52 @@
+package com.streamr.client.protocol
+
+import com.squareup.moshi.JsonReader
+import com.streamr.client.protocol.control_layer.DeleteRequest
+import com.streamr.client.protocol.control_layer.DeleteRequestAdapter
+import okio.Buffer
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+
+class DeleteRequestAdapterSpec extends Specification {
+
+    private static Charset utf8 = Charset.forName("UTF-8")
+
+    DeleteRequestAdapter adapter
+    Buffer buffer
+
+    void setup() {
+        adapter = new DeleteRequestAdapter()
+        buffer = new Buffer()
+    }
+
+    private static DeleteRequest toMsg(DeleteRequestAdapter adapter, String json) {
+        JsonReader reader = JsonReader.of(new Buffer().writeString(json, Charset.forName("UTF-8")))
+        reader.beginArray()
+        reader.nextInt()
+        reader.nextInt()
+        DeleteRequest msg = adapter.fromJson(reader)
+        reader.endArray()
+        return msg
+    }
+
+    void "fromJson"() {
+        String json = '[1,14,"streamId",0,123,456]'
+        when:
+        DeleteRequest msg = toMsg(adapter, json)
+        then:
+        msg.streamId == "streamId"
+        msg.streamPartition == 0
+        msg.fromTimestamp == 123L
+        msg.toTimestamp == 456L
+    }
+
+    void "toJson"() {
+        DeleteRequest request = new DeleteRequest("streamId", 0, 123L, 456L)
+        when:
+        adapter.toJson(buffer, request)
+
+        then:
+        buffer.readString(utf8) == '[1,14,"streamId",0,123,456]'
+    }
+}

--- a/src/test/groovy/com/streamr/client/protocol/DeleteRequestAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/DeleteRequestAdapterSpec.groovy
@@ -31,22 +31,23 @@ class DeleteRequestAdapterSpec extends Specification {
     }
 
     void "fromJson"() {
-        String json = '[1,14,"streamId",0,123,456]'
+        String json = '[1,14,"streamId",0,"requestId",123,456]'
         when:
         DeleteRequest msg = toMsg(adapter, json)
         then:
         msg.streamId == "streamId"
         msg.streamPartition == 0
+        msg.requestId == "requestId"
         msg.fromTimestamp == 123L
         msg.toTimestamp == 456L
     }
 
     void "toJson"() {
-        DeleteRequest request = new DeleteRequest("streamId", 0, 123L, 456L)
+        DeleteRequest request = new DeleteRequest("streamId", 0, "requestId", 123L, 456L)
         when:
         adapter.toJson(buffer, request)
 
         then:
-        buffer.readString(utf8) == '[1,14,"streamId",0,123,456]'
+        buffer.readString(utf8) == '[1,14,"streamId",0,"requestId",123,456]'
     }
 }

--- a/src/test/groovy/com/streamr/client/protocol/DeleteResponseAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/DeleteResponseAdapterSpec.groovy
@@ -1,0 +1,53 @@
+package com.streamr.client.protocol
+
+import com.squareup.moshi.JsonReader
+import com.streamr.client.protocol.control_layer.DeleteRequest
+import com.streamr.client.protocol.control_layer.DeleteRequestAdapter
+import com.streamr.client.protocol.control_layer.DeleteResponse
+import com.streamr.client.protocol.control_layer.DeleteResponseAdapter
+import okio.Buffer
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+
+class DeleteResponseAdapterSpec extends Specification {
+
+    private static Charset utf8 = Charset.forName("UTF-8")
+
+    DeleteResponseAdapter adapter
+    Buffer buffer
+
+    void setup() {
+        adapter = new DeleteResponseAdapter()
+        buffer = new Buffer()
+    }
+
+    private static DeleteResponse toMsg(DeleteResponseAdapter adapter, String json) {
+        JsonReader reader = JsonReader.of(new Buffer().writeString(json, Charset.forName("UTF-8")))
+        reader.beginArray()
+        reader.nextInt()
+        reader.nextInt()
+        DeleteResponse msg = adapter.fromJson(reader)
+        reader.endArray()
+        return msg
+    }
+
+    void "fromJson"() {
+        String json = '[1,15,"streamId",0,true]'
+        when:
+        DeleteResponse msg = toMsg(adapter, json)
+        then:
+        msg.streamId == "streamId"
+        msg.streamPartition == 0
+        msg.status
+    }
+
+    void "toJson"() {
+        DeleteResponse response = new DeleteResponse("streamId", 0, true)
+        when:
+        adapter.toJson(buffer, response)
+
+        then:
+        buffer.readString(utf8) == '[1,15,"streamId",0,true]'
+    }
+}

--- a/src/test/groovy/com/streamr/client/protocol/DeleteResponseAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/DeleteResponseAdapterSpec.groovy
@@ -33,7 +33,7 @@ class DeleteResponseAdapterSpec extends Specification {
     }
 
     void "fromJson"() {
-        String json = '[1,15,"streamId",0,true]'
+        String json = '[1,15,"streamId",0,"requestId",true]'
         when:
         DeleteResponse msg = toMsg(adapter, json)
         then:
@@ -43,11 +43,11 @@ class DeleteResponseAdapterSpec extends Specification {
     }
 
     void "toJson"() {
-        DeleteResponse response = new DeleteResponse("streamId", 0, true)
+        DeleteResponse response = new DeleteResponse("streamId", 0, "requestId", true)
         when:
         adapter.toJson(buffer, response)
 
         then:
-        buffer.readString(utf8) == '[1,15,"streamId",0,true]'
+        buffer.readString(utf8) == '[1,15,"streamId",0,"requestId",true]'
     }
 }


### PR DESCRIPTION
This PR adds
- the `DeleteRequest` and `DeleteResponse` types to the Java implementation of the protocol.
- public methods to `StreamrClient` to send `DeleteRequest`
- handling of `DeleteResponse`

TODO in next PRs:
- Implement the same message types in the Javascript protocol
- Same methods in the Javascript client
- Handling of `DeleteRequest` and sending of `DeleteResponse` in the storage node