### PR TITLE
init retry

### DIFF
--- a/src/integrationTest/groovy/com/streamr/client/StreamrWebsocketSpec.groovy
+++ b/src/integrationTest/groovy/com/streamr/client/StreamrWebsocketSpec.groovy
@@ -105,7 +105,6 @@ class StreamrWebsocketSpec extends StreamrIntegrationSpecification {
 		}
 
 		then:
-		Thread.sleep(2000)
 		// All messages have been received by subscriber
 		msgCount == 10
 		timeout > 0

--- a/src/integrationTest/groovy/com/streamr/client/StreamrWebsocketSpec.groovy
+++ b/src/integrationTest/groovy/com/streamr/client/StreamrWebsocketSpec.groovy
@@ -105,6 +105,7 @@ class StreamrWebsocketSpec extends StreamrIntegrationSpecification {
 		}
 
 		then:
+		Thread.sleep(2000)
 		// All messages have been received by subscriber
 		msgCount == 10
 		timeout > 0

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -38,8 +38,11 @@ public class StreamrClient extends StreamrRESTClient {
 
     private static final Logger log = LogManager.getLogger();
 
+    private static final long CONNECTION_RETRY_INTERVAL = 5000;
+    private static final int CONNECTION_MAX_RETRIES = 10;
+
     // Underlying websocket implementation
-    private final WebSocketClient websocket;
+    private WebSocketClient websocket;
 
     protected final Subscriptions subs = new Subscriptions();
 
@@ -95,6 +98,14 @@ public class StreamrClient extends StreamrRESTClient {
         }
         msgCreationUtil = new MessageCreationUtil(publisherId, signingUtil, options.getEncryptionOptions().getPublisherGroupKeys());
 
+        initWebsocket();
+    }
+
+    public StreamrClient(AuthenticationMethod authenticationMethod) {
+        this(new StreamrClientOptions(authenticationMethod));
+    }
+
+    private void initWebsocket() {
         try {
             this.websocket = new WebSocketClient(new URI(options.getWebsocketApiUrl())) {
                 @Override
@@ -113,18 +124,28 @@ public class StreamrClient extends StreamrRESTClient {
                 public void onClose(int code, String reason, boolean remote) {
                     log.info("Connection closed! Code: " + code + ", Reason: " + reason);
                     state = State.Disconnected;
-                    StreamrClient.this.onClose();
+                    if (!remote) {
+                        StreamrClient.this.onClose();
+                    }
                 }
 
                 @Override
                 public void onError(Exception ex) {
                     log.error(ex);
+                    if (ex instanceof IOException) {
+                        try {
+                            Thread.sleep(CONNECTION_RETRY_INTERVAL);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                        StreamrClient.this.reconnect();
+                    } else {
+                        if (state == State.Connecting) {
+                            errorWhileConnecting = ex;
+                        }
 
-                    if (state == State.Connecting) {
-                        errorWhileConnecting = ex;
+                        StreamrClient.this.onError(ex);
                     }
-
-                    StreamrClient.this.onError(ex);
                 }
 
                 @Override
@@ -136,10 +157,6 @@ public class StreamrClient extends StreamrRESTClient {
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public StreamrClient(AuthenticationMethod authenticationMethod) {
-        this(new StreamrClientOptions(authenticationMethod));
     }
 
     /*
@@ -156,23 +173,56 @@ public class StreamrClient extends StreamrRESTClient {
         return websocket;
     }
 
+    private void reconnect() {
+        initWebsocket();
+        websocket.connect();
+        waitForState(State.Connected);
+        StreamrClient.this.subs.forEach(StreamrClient.this::resubscribe);
+    }
+
     /**
      * Connects the websocket. Blocks until connected, or throws if the connection times out.
      */
     public void connect() throws ConnectionTimeoutException {
-        log.info("Connecting to " + options.getWebsocketApiUrl() + "...");
+        connect(0);
+    }
+
+    private void connect(int iter) throws ConnectionTimeoutException {
+        if (state == State.Connected) {
+            log.warn("Trying to connect when already connected to " + options.getWebsocketApiUrl());
+            return;
+        } else if (state == State.Connecting) {
+            log.warn("Trying to connect when already connecting to " + options.getWebsocketApiUrl());
+            return;
+        }
         state = State.Connecting;
 
-        websocket.connect();
-        waitForState(State.Connected);
+        if (iter == 0) {
+            log.info("Connecting to " + options.getWebsocketApiUrl() + "...");
+            websocket.connect();
+            waitForState(State.Connected);
+        } else {
+            log.info("Reconnecting to " + options.getWebsocketApiUrl() + "...");
+            reconnect();
+        }
 
         if (errorWhileConnecting != null) {
             Exception ex = errorWhileConnecting;
             errorWhileConnecting = null;
             throw new RuntimeException(ex);
         } else if (state != State.Connected) {
-            throw new ConnectionTimeoutException(options.getWebsocketApiUrl());
+            if (iter >= CONNECTION_MAX_RETRIES) {
+                throw new ConnectionTimeoutException(options.getWebsocketApiUrl());
+            }
+            log.warn("Failed to connect to " + options.getWebsocketApiUrl() + ". Going to retry in " + CONNECTION_RETRY_INTERVAL + " ms...");
+            try {
+                Thread.sleep(CONNECTION_RETRY_INTERVAL);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            connect(iter + 1);
         }
+        log.info("Connected to " + options.getWebsocketApiUrl());
     }
 
     /**
@@ -202,6 +252,13 @@ public class StreamrClient extends StreamrRESTClient {
                 // ignore
             }
         }
+    }
+
+    private void send(ControlMessage message) {
+        if (getState() != State.Connected) {
+            connect();
+        }
+        this.websocket.send(message.toJson());
     }
 
     public State getState() {
@@ -340,7 +397,7 @@ public class StreamrClient extends StreamrRESTClient {
             }
         }
 
-        SubscribeRequest subscribeRequest = new SubscribeRequest(stream.getId(), partition, session.getSessionToken());
+        SubscribeRequest subscribeRequest = new SubscribeRequest(stream.getId(), partition, getSessionToken());
 
         Subscription sub;
         if (resendOption == null) {
@@ -357,12 +414,18 @@ public class StreamrClient extends StreamrRESTClient {
             ResendRangeRequest req = new ResendRangeRequest(stream.getId(), partition,
                     sub.getId(), from, to, publisherId, msgChainId, getSessionToken());
             sub.setResending(true);
-            this.websocket.send(req.toJson());
+            send(req);
         });
         subs.add(sub);
         sub.setState(Subscription.State.SUBSCRIBING);
-        this.websocket.send(subscribeRequest.toJson());
+        send(subscribeRequest);
         return sub;
+    }
+
+    private void resubscribe(Subscription sub) {
+        SubscribeRequest subscribeRequest = new SubscribeRequest(sub.getStreamId(), sub.getPartition(), getSessionToken());
+        sub.setState(Subscription.State.SUBSCRIBING);
+        send(subscribeRequest);
     }
 
     /*
@@ -399,7 +462,7 @@ public class StreamrClient extends StreamrRESTClient {
         UnsubscribeRequest unsubscribeRequest = new UnsubscribeRequest(sub.getStreamId(), sub.getPartition());
         sub.setState(Subscription.State.UNSUBSCRIBING);
         sub.setResending(false);
-        this.websocket.send(unsubscribeRequest.toJson());
+        send(unsubscribeRequest);
     }
 
     private void handleSubcribeResponse(SubscribeResponse res) throws SubscriptionNotFoundException {
@@ -408,7 +471,7 @@ public class StreamrClient extends StreamrRESTClient {
         if (sub.hasResendOptions()) {
             ResendOption resendOption = sub.getResendOption();
             ControlMessage req = resendOption.toRequest(res.getStreamId(), res.getStreamPartition(), sub.getId(), this.getSessionToken());
-            this.websocket.send(req.toJson());
+            send(req);
             OneTimeResend resend = new OneTimeResend(websocket, req, options.getResendTimeout(), sub);
             secondResends.put(sub.getId(), resend);
             resend.start();

--- a/src/main/java/com/streamr/client/options/StreamrClientOptions.java
+++ b/src/main/java/com/streamr/client/options/StreamrClientOptions.java
@@ -15,6 +15,7 @@ public class StreamrClientOptions {
     private String websocketApiUrl = "wss://www.streamr.com/api/v1/ws?controlLayerVersion=1&messageLayerVersion=30";
     private String restApiUrl = "https://www.streamr.com/api/v1";
     private long connectionTimeoutMillis = 10 * 1000;
+    private long reconnectRetryInterval = 10 * 1000;
     private int propagationTimeout = 5000;
     private int resendTimeout = 5000;
 
@@ -81,6 +82,14 @@ public class StreamrClientOptions {
 
     public void setConnectionTimeoutMillis(long connectionTimeoutMillis) {
         this.connectionTimeoutMillis = connectionTimeoutMillis;
+    }
+
+    public long getReconnectRetryInterval() {
+        return reconnectRetryInterval;
+    }
+
+    public void setReconnectRetryInterval(long reconnectRetryInterval) {
+        this.reconnectRetryInterval = reconnectRetryInterval;
     }
 
     public boolean getPublishSignedMsgs() {

--- a/src/main/java/com/streamr/client/utils/OneTimeResend.java
+++ b/src/main/java/com/streamr/client/utils/OneTimeResend.java
@@ -29,7 +29,7 @@ public class OneTimeResend extends Thread {
                 ws.send(controlMessage.toJson());
             }
         } catch (InterruptedException e) {
-            log.error(e);
+            log.warn("Second resend request was canceled.");
         }
     }
 }

--- a/src/main/java/com/streamr/client/utils/Subscriptions.java
+++ b/src/main/java/com/streamr/client/utils/Subscriptions.java
@@ -6,6 +6,7 @@ import com.streamr.client.subs.Subscription;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class Subscriptions {
 
@@ -41,5 +42,9 @@ public class Subscriptions {
         } else {
             throw new SubscriptionNotFoundException(sub.getStreamId(), sub.getPartition());
         }
+    }
+
+    public void forEach(Consumer<Subscription> f) {
+        subsByKey.values().forEach(f);
     }
 }

--- a/src/test/groovy/com/streamr/client/TestWebSocketServer.java
+++ b/src/test/groovy/com/streamr/client/TestWebSocketServer.java
@@ -5,8 +5,10 @@ import org.java_websocket.WebSocket;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.LinkedList;
+import java.util.function.Function;
 
 public class TestWebSocketServer extends WebSocketServer {
     private LinkedList<String> msgs = new LinkedList<>();

--- a/src/test/groovy/com/streamr/client/TestingStreamrClient.java
+++ b/src/test/groovy/com/streamr/client/TestingStreamrClient.java
@@ -3,10 +3,21 @@ package com.streamr.client;
 import com.streamr.client.exceptions.SubscriptionNotFoundException;
 import com.streamr.client.options.StreamrClientOptions;
 import com.streamr.client.protocol.control_layer.ControlMessage;
+import com.streamr.client.rest.UserInfo;
 
 public class TestingStreamrClient extends StreamrClient {
     public TestingStreamrClient(StreamrClientOptions options) {
         super(options);
+    }
+
+    @Override
+    public UserInfo getUserInfo() {
+        return new UserInfo("name", "username", "id");
+    }
+
+    @Override
+    public String getSessionToken() {
+        return "sessionToken";
     }
 
     public void receiveMessage(ControlMessage msg) {


### PR DESCRIPTION
If the node goes down, the client now tries to reconnect with a fixed interval. Once it is reconnected, it sends a new subscribe request for each subscription that was interrupted.
I also did some manual testing on some integration tests (killing `data-api` in the middle of the test)