### PR TITLE
Recover from failed gapfills

### DIFF
--- a/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
+++ b/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
@@ -142,6 +142,13 @@ public class OrderedMsgChain {
                         gapFillFailedHandler.apply(new GapFillFailedException(from, to, publisherId, msgChainId, MAX_GAP_REQUESTS));
                     } finally {
                         clearGap();
+
+                        // TODO: make it configurable how to handle this error situation.
+                        // Currently unrecoverable gaps are just ignored, and processing continues from the next
+                        // message after the gap.
+                        log.warn("Unable to fill gap: Max retries reached! Ignoring the error and continuing from the first processable message: " + queue.peek().getMessageRef());
+                        lastReceived = queue.peek().getPreviousMessageRef();
+                        checkQueue();
                     }
                 }
             }

--- a/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
+++ b/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
@@ -78,6 +78,10 @@ public class OrderedMsgChain {
         }
     }
 
+    public boolean hasGap() {
+        return gap != null;
+    }
+
     public String getPublisherId() {
         return publisherId;
     }
@@ -134,8 +138,11 @@ public class OrderedMsgChain {
                     gapRequestCount++;
                     gapHandler.apply(from, to, publisherId, msgChainId);
                 } else {
-                    gapFillFailedHandler.apply(new GapFillFailedException(from, to, publisherId, msgChainId, MAX_GAP_REQUESTS));
-                    clearGap();
+                    try {
+                        gapFillFailedHandler.apply(new GapFillFailedException(from, to, publisherId, msgChainId, MAX_GAP_REQUESTS));
+                    } finally {
+                        clearGap();
+                    }
                 }
             }
         };

--- a/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
@@ -142,7 +142,7 @@ class OrderedMsgChainSpec extends Specification {
                 @Override
                 Void apply(GapFillFailedException e) {
                     expected = e
-                    return null
+                    throw e // mimic behavior of default handler
                 }
             }, 100L, 100L)
         } catch (GapFillFailedException e) {
@@ -152,10 +152,15 @@ class OrderedMsgChainSpec extends Specification {
         util.add(msg1)
         util.add(msg3)
         Thread.sleep(1200L)
+
         then:
         expected != null
         gapHandlerCount == 10
+
+        then: "gap should be cleared"
+        !util.hasGap()
     }
+
     void "handles unordered messages in order (large randomized test)"() {
         ArrayList<StreamMessage> expected = [msg1]
         ArrayList<StreamMessage> shuffled = []


### PR DESCRIPTION
- Fixed an issue where `clearGap()` is not called if the `gapFillFailedHandler` throws
- Tweaked default behavior to log a warning and ignore the failure by continuing from the next message in queue.

Would be good to have tests & make the behavior configurable. I'll leave it to you @mthambipillai. Maybe it's best to merge this PR and continue on the technical debt in a separate one.

`engine-and-editor` has currently been hotfixed _with these changes in place_, although they are not yet published to Maven. So the sooner we get these into an actual release, the better.