### PR TITLE
Add re-connecting to onClose event

### DIFF
--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -57,9 +57,6 @@ public class StreamrClient extends StreamrRESTClient {
     private final HashMap<String, OneTimeResend> secondResends = new HashMap<>();
 
     private ErrorMessageHandler errorMessageHandler;
-    public void setErrorMessageHandler(ErrorMessageHandler errorMessageHandler) {
-        this.errorMessageHandler = errorMessageHandler;
-    }
 
     public StreamrClient(StreamrClientOptions options) {
         super(options);
@@ -243,6 +240,10 @@ public class StreamrClient extends StreamrRESTClient {
         } else if (state != State.Disconnected) {
             throw new ConnectionTimeoutException(options.getWebsocketApiUrl());
         }
+    }
+
+    public void setErrorMessageHandler(ErrorMessageHandler errorMessageHandler) {
+        this.errorMessageHandler = errorMessageHandler;
     }
 
     private void waitForState(State target) {

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -163,7 +163,7 @@ class StreamrClientSpec extends Specification {
 
     void "subscribed client reconnects if server is temporarily down"() {
         when:
-        client.options.reconnectRetryInterval = 100
+        client.options.reconnectRetryInterval = 1000
 
         Stream stream = new Stream("", "")
         stream.setId("test-stream")
@@ -186,13 +186,13 @@ class StreamrClientSpec extends Specification {
                 server = new TestWebSocketServer("localhost", 6000)
                 sleep(250)
                 server.start()
-                sleep(500)
+                sleep(1000)
                 server.sendSubscribeToAll(stream.getId(), 0)
                 server.sendToAll(stream, Collections.singletonMap("key", "msg #2"))
             }
         }.start()
 
-        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1, factor: 1)
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.25, factor: 1)
 
         then:
         conditions.eventually {

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -163,7 +163,7 @@ class StreamrClientSpec extends Specification {
 
     void "subscribed client reconnects if server is temporarily down"() {
         when:
-        client.options.reconnectRetryInterval = 1000
+        client.options.reconnectRetryInterval = 100
 
         Stream stream = new Stream("", "")
         stream.setId("test-stream")
@@ -186,13 +186,13 @@ class StreamrClientSpec extends Specification {
                 server = new TestWebSocketServer("localhost", 6000)
                 sleep(250)
                 server.start()
-                sleep(1000)
+                sleep(500)
                 server.sendSubscribeToAll(stream.getId(), 0)
                 server.sendToAll(stream, Collections.singletonMap("key", "msg #2"))
             }
         }.start()
 
-        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.25, factor: 1)
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1, factor: 1)
 
         then:
         conditions.eventually {

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -36,7 +36,6 @@ class StreamrClientSpec extends Specification {
         SigningOptions signingOptions = new SigningOptions(SigningOptions.SignatureComputationPolicy.NEVER, SigningOptions.SignatureVerificationPolicy.NEVER)
 
         StreamrClientOptions options = new StreamrClientOptions(new ApiKeyAuthenticationMethod("apikey"), signingOptions, EncryptionOptions.getDefault(), server.getWsUrl(), "", gapFillTimeout, retryResendAfter)
-        options.setReconnectRetryInterval(1000)
         client = new TestingStreamrClient(options)
     }
 
@@ -164,6 +163,8 @@ class StreamrClientSpec extends Specification {
 
     void "subscribed client reconnects if server is temporarily down"() {
         when:
+        client.options.reconnectRetryInterval = 1000
+
         Stream stream = new Stream("", "")
         stream.setId("test-stream")
         stream.setPartitions(1)

--- a/src/test/groovy/com/streamr/client/TestWebSocketServer.java
+++ b/src/test/groovy/com/streamr/client/TestWebSocketServer.java
@@ -1,22 +1,39 @@
 package com.streamr.client;
 
+import com.streamr.client.protocol.control_layer.BroadcastMessage;
 import com.streamr.client.protocol.control_layer.ControlMessage;
+import com.streamr.client.protocol.control_layer.SubscribeResponse;
+import com.streamr.client.protocol.message_layer.StreamMessage;
+import com.streamr.client.rest.Stream;
+import com.streamr.client.utils.MessageCreationUtil;
 import org.java_websocket.WebSocket;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Date;
 import java.util.LinkedList;
-import java.util.function.Function;
+import java.util.Map;
 
 public class TestWebSocketServer extends WebSocketServer {
+    private final MessageCreationUtil msgCreationUtil = new MessageCreationUtil("publisherId", null);
     private LinkedList<String> msgs = new LinkedList<>();
     private String wsUrl;
 
     public TestWebSocketServer(String host, int port) {
         super(new InetSocketAddress(host, port));
         wsUrl = "ws://" + this.getAddress().getHostString() + ":" + this.getAddress().getPort();
+    }
+
+    public void sendSubscribeToAll(String streamId, int partition) {
+        SubscribeResponse subscribeResponse = new SubscribeResponse(streamId, partition);
+        getConnections().forEach(webSocket -> webSocket.send(subscribeResponse.toJson()));
+    }
+
+    public void sendToAll(Stream stream, Map<String, Object> payload) {
+        StreamMessage streamMessage = msgCreationUtil.createStreamMessage(stream, payload, new Date(), null);
+        BroadcastMessage req = new BroadcastMessage(streamMessage);
+        getConnections().forEach((webSocket -> webSocket.send(req.toJson())));
     }
 
     @Override


### PR DESCRIPTION
StreamrClient was not re-connecting on a clean handshake close (`onClose`) but only on error (`onError`). Extracted re-connect logic into a method and then reused it in `onClose` callback. Added a small integration test to verify that client indeed re-connects and receives messages.