### PR TITLE
Limit the queue size in OrderedMsgChain

### DIFF
--- a/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
+++ b/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
@@ -17,6 +17,8 @@ public class OrderedMsgChain {
     private static final Logger log = LogManager.getLogger();
     private static final int MAX_GAP_REQUESTS = 10;
 
+    static final int MAX_QUEUE_SIZE = 5000;
+
     private String publisherId;
     private String msgChainId;
     private Consumer<StreamMessage> inOrderHandler;
@@ -64,7 +66,12 @@ public class OrderedMsgChain {
             if (gap == null) {
                 scheduleGap();
             }
-            queue.offer(unorderedMsg);
+            // Prevent memory exhaustion under unusual conditions by limiting the queue size
+            if (queue.size() < MAX_QUEUE_SIZE) {
+                queue.offer(unorderedMsg);
+            } else {
+                throw new IllegalStateException("Queue is full! Message: " + unorderedMsg.toJson());
+            }
         }
     }
 

--- a/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
+++ b/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
@@ -17,7 +17,7 @@ public class OrderedMsgChain {
     private static final Logger log = LogManager.getLogger();
     private static final int MAX_GAP_REQUESTS = 10;
 
-    static final int MAX_QUEUE_SIZE = 5000;
+    static final int MAX_QUEUE_SIZE = 10000;
 
     private String publisherId;
     private String msgChainId;

--- a/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
@@ -209,4 +209,24 @@ class OrderedMsgChainSpec extends Specification {
         then:
         result
     }
+
+    void "throws if the queue is full"() {
+        final int received = 0;
+        OrderedMsgChain util = new OrderedMsgChain("publisherId", "msgChainId", new Consumer<StreamMessage>() {
+            @Override
+            void accept(StreamMessage streamMessage) {
+                received++;
+            }
+        }, null, 5000L, 5000L)
+
+        when:
+        util.add(createMessage(-1, null))
+        // there's a gap between the above and the below messages, so below messages are queued
+        for (int i=1; i<=OrderedMsgChain.MAX_QUEUE_SIZE + 1; i++) {
+            util.add(createMessage(i, i-1))
+        }
+
+        then:
+        thrown(IllegalStateException)
+    }
 }


### PR DESCRIPTION
Quick fix to prevent the queue from growing totally without bound in `OrderedMsgChain`.