### PR TITLE
Make OrderedMsgChain thread-safe

### DIFF
--- a/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
+++ b/src/main/java/com/streamr/client/utils/OrderedMsgChain.java
@@ -51,7 +51,7 @@ public class OrderedMsgChain {
         this(publisherId, msgChainId, inOrderHandler, gapHandler, (GapFillFailedException e) -> { throw e; }, propagationTimeout, resendTimeout);
     }
 
-    public void add(StreamMessage unorderedMsg) {
+    public synchronized void add(StreamMessage unorderedMsg) {
         MessageRef ref = unorderedMsg.getMessageRef();
         if (lastReceived != null && ref.compareTo(lastReceived) <= 0) {
             log.debug("Already received message: " + ref + ", lastReceivedMsgRef: " + lastReceived + ". Ignoring message.");
@@ -68,7 +68,7 @@ public class OrderedMsgChain {
         }
     }
 
-    public void clearGap() {
+    public synchronized void clearGap() {
         if (gap != null) {
             gap.cancel();
             gap = null;
@@ -78,7 +78,7 @@ public class OrderedMsgChain {
         }
     }
 
-    public boolean hasGap() {
+    public synchronized boolean hasGap() {
         return gap != null;
     }
 
@@ -90,11 +90,11 @@ public class OrderedMsgChain {
         return msgChainId;
     }
 
-    public void setLastReceived(MessageRef lastReceived) {
+    public synchronized void setLastReceived(MessageRef lastReceived) {
         this.lastReceived = lastReceived;
     }
 
-    public MessageRef getLastReceived() {
+    public synchronized MessageRef getLastReceived() {
         return lastReceived;
     }
 

--- a/src/main/java/com/streamr/client/utils/OrderingUtil.java
+++ b/src/main/java/com/streamr/client/utils/OrderingUtil.java
@@ -43,7 +43,7 @@ public class OrderingUtil {
         }
     }
 
-    private OrderedMsgChain getChain(String publisherId, String msgChainId) {
+    private synchronized OrderedMsgChain getChain(String publisherId, String msgChainId) {
         String key = publisherId + msgChainId;
         if (!chains.containsKey(key)) {
             chains.put(key, new OrderedMsgChain(publisherId, msgChainId, inOrderHandler,
@@ -60,7 +60,7 @@ public class OrderingUtil {
         return gapHandler;
     }
 
-    public void addChains(ArrayList<OrderedMsgChain> previousChains) {
+    public synchronized void addChains(ArrayList<OrderedMsgChain> previousChains) {
         for (OrderedMsgChain chain: previousChains) {
             String key = chain.getPublisherId() + chain.getMsgChainId();
             OrderedMsgChain newChain = new OrderedMsgChain(chain.getPublisherId(), chain.getMsgChainId(),

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -144,6 +144,7 @@ class StreamrClientSpec extends Specification {
                 server = new TestWebSocketServer("localhost", 6000)
                 sleep(2000)
                 server.start()
+                sleep(2000)
             }
         }
         then:
@@ -181,12 +182,12 @@ class StreamrClientSpec extends Specification {
             void run() {
                 server.sendSubscribeToAll(stream.getId(), 0)
                 server.sendToAll(stream, Collections.singletonMap("key", "msg #1"))
-                sleep(250)
+                sleep(2000)
                 server.stop()
                 server = new TestWebSocketServer("localhost", 6000)
-                sleep(250)
+                sleep(2000)
                 server.start()
-                sleep(1000)
+                sleep(2000)
                 server.sendSubscribeToAll(stream.getId(), 0)
                 server.sendToAll(stream, Collections.singletonMap("key", "msg #2"))
             }

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -39,14 +39,6 @@ class StreamrClientSpec extends Specification {
         client = new TestingStreamrClient(options)
     }
 
-    void cleanup() {
-        /*
-        if (client.getState() != StreamrClient.State.Disconnected) {
-            client.disconnect()
-        }
-         */
-    }
-
     StreamMessageV31 createMsg(String streamId, long timestamp, long sequenceNumber, Long prevTimestamp, Long prevSequenceNumber) {
         MessageID msgId = new MessageID(streamId, 0, timestamp, sequenceNumber, "", "")
         MessageRef prev = prevTimestamp == null ? null : new MessageRef(prevTimestamp, prevSequenceNumber)

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -39,6 +39,14 @@ class StreamrClientSpec extends Specification {
         client = new TestingStreamrClient(options)
     }
 
+    void cleanup() {
+        /*
+        if (client.getState() != StreamrClient.State.Disconnected) {
+            client.disconnect()
+        }
+         */
+    }
+
     StreamMessageV31 createMsg(String streamId, long timestamp, long sequenceNumber, Long prevTimestamp, Long prevSequenceNumber) {
         MessageID msgId = new MessageID(streamId, 0, timestamp, sequenceNumber, "", "")
         MessageRef prev = prevTimestamp == null ? null : new MessageRef(prevTimestamp, prevSequenceNumber)

--- a/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
@@ -5,6 +5,7 @@ import com.streamr.client.protocol.message_layer.MessageRef;
 import com.streamr.client.protocol.message_layer.StreamMessage;
 import com.streamr.client.protocol.message_layer.StreamMessageV31;
 import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
 
 import java.util.function.Consumer
 import java.util.function.Function
@@ -209,4 +210,31 @@ class OrderedMsgChainSpec extends Specification {
         then:
         result
     }
+
+    void "is thread-safe"() {
+        int received = 0
+        OrderedMsgChain.GapHandlerFunction gapHandler = Mock(OrderedMsgChain.GapHandlerFunction)
+        OrderedMsgChain util = new OrderedMsgChain("publisherId", "msgChainId", new Consumer<StreamMessage>() {
+            @Override
+            void accept(StreamMessage streamMessage) {
+                received++
+            }
+        }, gapHandler, 5000L, 5000L)
+        when:
+        Closure produce = {
+            for (int i=0; i<1000; i++) {
+                util.add(createMessage(i, (i == 0 ? null : i - 1)))
+            }
+        }
+        // Start 2 threads that produce the same messages in parallel
+        Thread.start(produce)
+        Thread.start(produce)
+
+        then:
+        new PollingConditions(timeout: 10).eventually {
+            received == 1000
+        }
+        0 * gapHandler.apply(_, _, _, _)
+    }
+
 }

--- a/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
@@ -231,7 +231,9 @@ class OrderedMsgChainSpec extends Specification {
         thrown(IllegalStateException)
     }
 
-    void "is thread-safe"() {
+    // Warning: non-deterministic test. If you see flakiness in this test, it may indicate
+    // something is wrong in the thread-safety of the class under test.
+    void "handles input from multiple threads correctly"() {
         int received = 0
         OrderedMsgChain.GapHandlerFunction gapHandler = Mock(OrderedMsgChain.GapHandlerFunction)
         OrderedMsgChain util = new OrderedMsgChain("publisherId", "msgChainId", new Consumer<StreamMessage>() {


### PR DESCRIPTION
This PR attempts to add thread-safety to `OrderedMsgChain`. All public methods are now `synchronized` and the internal gapfill timer also synchronizes on the instance object, avoiding inconsistent state resulting from multiple threads mutating the state in parallel.