### PR TITLE
Resend per request

### DIFF
--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -578,13 +578,11 @@ public class StreamrClient extends StreamrRESTClient {
     }
 
     private void handleResendResponseNoResend(ResendResponseNoResend res) throws InvalidResendResponseException {
-        Subscription sub = resendUtil.getSub(res);
-        sub.endResend();
+        resendUtil.deleteDoneSub(res);
     }
 
     private void handleResendResponseResent(ResendResponseResent res) throws InvalidResendResponseException {
-        Subscription sub = resendUtil.getSub(res);
-        sub.endResend();
+        resendUtil.deleteDoneSub(res);
     }
 
     private HashMap<String, UnencryptedGroupKey> getKeysPerPublisher(String streamId) {

--- a/src/main/java/com/streamr/client/exceptions/InvalidResendResponseException.java
+++ b/src/main/java/com/streamr/client/exceptions/InvalidResendResponseException.java
@@ -1,0 +1,7 @@
+package com.streamr.client.exceptions;
+
+public class InvalidResendResponseException extends Exception {
+    public InvalidResendResponseException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/streamr/client/options/ResendFromOption.java
+++ b/src/main/java/com/streamr/client/options/ResendFromOption.java
@@ -37,7 +37,7 @@ public class ResendFromOption extends ResendOption {
     }
 
     @Override
-    public ControlMessage toRequest(String streamId, int streamPartition, String subId, String sessionToken) {
-        return new ResendFromRequest(streamId, streamPartition, subId, from, publisherId, msgChainId, sessionToken);
+    public ControlMessage toRequest(String streamId, int streamPartition, String requestId, String sessionToken) {
+        return new ResendFromRequest(streamId, streamPartition, requestId, from, publisherId, msgChainId, sessionToken);
     }
 }

--- a/src/main/java/com/streamr/client/options/ResendLastOption.java
+++ b/src/main/java/com/streamr/client/options/ResendLastOption.java
@@ -15,7 +15,7 @@ public class ResendLastOption extends ResendOption {
     }
 
     @Override
-    public ControlMessage toRequest(String streamId, int streamPartition, String subId, String sessionToken) {
-        return new ResendLastRequest(streamId, streamPartition, subId, numberLast, sessionToken);
+    public ControlMessage toRequest(String streamId, int streamPartition, String requestId, String sessionToken) {
+        return new ResendLastRequest(streamId, streamPartition, requestId, numberLast, sessionToken);
     }
 }

--- a/src/main/java/com/streamr/client/options/ResendOption.java
+++ b/src/main/java/com/streamr/client/options/ResendOption.java
@@ -4,5 +4,5 @@ import com.streamr.client.protocol.control_layer.ControlMessage;
 
 public abstract class ResendOption {
     //The returned ControlMessage is either ResendLastRequest, ResendFromRequest or ResendRangeRequest
-    public abstract ControlMessage toRequest(String streamId, int streamPartition, String subId, String sessionToken);
+    public abstract ControlMessage toRequest(String streamId, int streamPartition, String requestId, String sessionToken);
 }

--- a/src/main/java/com/streamr/client/options/ResendRangeOption.java
+++ b/src/main/java/com/streamr/client/options/ResendRangeOption.java
@@ -26,8 +26,8 @@ public class ResendRangeOption extends ResendOption {
     }
 
     @Override
-    public ControlMessage toRequest(String streamId, int streamPartition, String subId, String sessionToken) {
-        return new ResendRangeRequest(streamId, streamPartition, subId, from, to, publisherId, msgChainId, sessionToken);
+    public ControlMessage toRequest(String streamId, int streamPartition, String requestId, String sessionToken) {
+        return new ResendRangeRequest(streamId, streamPartition, requestId, from, to, publisherId, msgChainId, sessionToken);
     }
 
     public MessageRef getTo() {

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendFromRequest.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendFromRequest.java
@@ -7,18 +7,18 @@ public class ResendFromRequest extends ControlMessage {
 
     private final String streamId;
     private final int streamPartition;
-    private final String subId;
+    private final String requestId;
     private final MessageRef fromMsgRef;
     private final String publisherId;
     private final String msgChainId;
     private final String sessionToken;
 
-    public ResendFromRequest(String streamId, int streamPartition, String subId, MessageRef fromMsgRef,
+    public ResendFromRequest(String streamId, int streamPartition, String requestId, MessageRef fromMsgRef,
                              String publisherId, String msgChainId, String sessionToken) {
         super(TYPE);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
-        this.subId = subId;
+        this.requestId = requestId;
         this.fromMsgRef = fromMsgRef;
         this.publisherId = publisherId;
         this.msgChainId = msgChainId;
@@ -33,8 +33,8 @@ public class ResendFromRequest extends ControlMessage {
         return streamPartition;
     }
 
-    public String getSubId() {
-        return subId;
+    public String getRequestId() {
+        return requestId;
     }
 
     public MessageRef getFromMsgRef() {

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendFromRequestAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendFromRequestAdapter.java
@@ -14,12 +14,12 @@ public class ResendFromRequestAdapter extends ControlLayerAdapter<ResendFromRequ
     public ResendFromRequest fromJson(JsonReader reader) throws IOException {
         String streamId = reader.nextString();
         int streamPartition = reader.nextInt();
-        String subId = reader.nextString();
+        String requestId = reader.nextString();
         MessageRef from = msgRefAdapter.fromJson(reader);
         String publisherId = nullSafe(reader, r -> r.nextString());
         String msgChainId = nullSafe(reader, r -> r.nextString());
         String sessionToken = nullSafe(reader, r -> r.nextString());
-        return new ResendFromRequest(streamId, streamPartition, subId, from, publisherId, msgChainId, sessionToken);
+        return new ResendFromRequest(streamId, streamPartition, requestId, from, publisherId, msgChainId, sessionToken);
     }
 
     @Override
@@ -29,7 +29,7 @@ public class ResendFromRequestAdapter extends ControlLayerAdapter<ResendFromRequ
         writer.value(ResendFromRequest.TYPE);
         writer.value(value.getStreamId());
         writer.value(value.getStreamPartition());
-        writer.value(value.getSubId());
+        writer.value(value.getRequestId());
         msgRefAdapter.toJson(writer, value.getFromMsgRef());
         writer.value(value.getPublisherId());
         writer.value(value.getMsgChainId());

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendLastRequest.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendLastRequest.java
@@ -5,15 +5,15 @@ public class ResendLastRequest extends ControlMessage {
 
     private final String streamId;
     private final int streamPartition;
-    private final String subId;
+    private final String requestId;
     private final int numberLast;
     private final String sessionToken;
 
-    public ResendLastRequest(String streamId, int streamPartition, String subId, int numberLast, String sessionToken) {
+    public ResendLastRequest(String streamId, int streamPartition, String requestId, int numberLast, String sessionToken) {
         super(TYPE);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
-        this.subId = subId;
+        this.requestId = requestId;
         this.numberLast = numberLast;
         this.sessionToken = sessionToken;
     }
@@ -26,8 +26,8 @@ public class ResendLastRequest extends ControlMessage {
         return streamPartition;
     }
 
-    public String getSubId() {
-        return subId;
+    public String getRequestId() {
+        return requestId;
     }
 
     public int getNumberLast() {

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendLastRequestAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendLastRequestAdapter.java
@@ -11,10 +11,10 @@ public class ResendLastRequestAdapter extends ControlLayerAdapter<ResendLastRequ
     public ResendLastRequest fromJson(JsonReader reader) throws IOException {
         String streamId = reader.nextString();
         int streamPartition = reader.nextInt();
-        String subId = reader.nextString();
+        String requestId = reader.nextString();
         int numberLast = reader.nextInt();
         String sessionToken = nullSafe(reader, r -> r.nextString());
-        return new ResendLastRequest(streamId, streamPartition, subId, numberLast, sessionToken);
+        return new ResendLastRequest(streamId, streamPartition, requestId, numberLast, sessionToken);
     }
 
     @Override
@@ -24,7 +24,7 @@ public class ResendLastRequestAdapter extends ControlLayerAdapter<ResendLastRequ
         writer.value(ResendLastRequest.TYPE);
         writer.value(value.getStreamId());
         writer.value(value.getStreamPartition());
-        writer.value(value.getSubId());
+        writer.value(value.getRequestId());
         writer.value(value.getNumberLast());
         writer.value(value.getSessionToken());
         writer.endArray();

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendRangeRequest.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendRangeRequest.java
@@ -7,19 +7,19 @@ public class ResendRangeRequest extends ControlMessage {
 
     private final String streamId;
     private final int streamPartition;
-    private final String subId;
+    private final String requestId;
     private final MessageRef fromMsgRef;
     private final MessageRef toMsgRef;
     private final String publisherId;
     private final String msgChainId;
     private final String sessionToken;
 
-    public ResendRangeRequest(String streamId, int streamPartition, String subId, MessageRef fromMsgRef,
+    public ResendRangeRequest(String streamId, int streamPartition, String requestId, MessageRef fromMsgRef,
                               MessageRef toMsgRef, String publisherId, String msgChainId, String sessionToken) {
         super(TYPE);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
-        this.subId = subId;
+        this.requestId = requestId;
         this.fromMsgRef = fromMsgRef;
         this.toMsgRef = toMsgRef;
         this.publisherId = publisherId;
@@ -39,8 +39,8 @@ public class ResendRangeRequest extends ControlMessage {
         return streamPartition;
     }
 
-    public String getSubId() {
-        return subId;
+    public String getRequestId() {
+        return requestId;
     }
 
     public MessageRef getFromMsgRef() {

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendRangeRequestAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendRangeRequestAdapter.java
@@ -14,13 +14,13 @@ public class ResendRangeRequestAdapter extends ControlLayerAdapter<ResendRangeRe
     public ResendRangeRequest fromJson(JsonReader reader) throws IOException {
         String streamId = reader.nextString();
         int streamPartition = reader.nextInt();
-        String subId = reader.nextString();
+        String requestId = reader.nextString();
         MessageRef from = msgRefAdapter.fromJson(reader);
         MessageRef to = msgRefAdapter.fromJson(reader);
         String publisherId = nullSafe(reader, r -> r.nextString());
         String msgChainId = nullSafe(reader, r -> r.nextString());
         String sessionToken = nullSafe(reader, r -> r.nextString());
-        return new ResendRangeRequest(streamId, streamPartition, subId, from, to, publisherId, msgChainId, sessionToken);
+        return new ResendRangeRequest(streamId, streamPartition, requestId, from, to, publisherId, msgChainId, sessionToken);
     }
 
     @Override
@@ -30,7 +30,7 @@ public class ResendRangeRequestAdapter extends ControlLayerAdapter<ResendRangeRe
         writer.value(ResendRangeRequest.TYPE);
         writer.value(value.getStreamId());
         writer.value(value.getStreamPartition());
-        writer.value(value.getSubId());
+        writer.value(value.getRequestId());
         msgRefAdapter.toJson(writer, value.getFromMsgRef());
         msgRefAdapter.toJson(writer, value.getToMsgRef());
         writer.value(value.getPublisherId());

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendResponse.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendResponse.java
@@ -4,13 +4,13 @@ public abstract class ResendResponse extends ControlMessage {
 
     private String streamId;
     private int streamPartition;
-    private String subId;
+    private String requestId;
 
-    public ResendResponse(int type, String streamId, int streamPartition, String subId) {
+    public ResendResponse(int type, String streamId, int streamPartition, String requestId) {
         super(type);
         this.streamId = streamId;
         this.streamPartition = streamPartition;
-        this.subId = subId;
+        this.requestId = requestId;
     }
 
     public String getStreamId() {
@@ -21,7 +21,7 @@ public abstract class ResendResponse extends ControlMessage {
         return streamPartition;
     }
 
-    public String getSubId() {
-        return subId;
+    public String getRequestId() {
+        return requestId;
     }
 }

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseNoResend.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseNoResend.java
@@ -3,7 +3,7 @@ package com.streamr.client.protocol.control_layer;
 public class ResendResponseNoResend extends ResendResponse {
     public static final int TYPE = 6;
 
-    public ResendResponseNoResend(String streamId, int streamPartition, String subId) {
-        super(TYPE, streamId, streamPartition, subId);
+    public ResendResponseNoResend(String streamId, int streamPartition, String requestId) {
+        super(TYPE, streamId, streamPartition, requestId);
     }
 }

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseNoResendAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseNoResendAdapter.java
@@ -11,8 +11,8 @@ public class ResendResponseNoResendAdapter extends ControlLayerAdapter<ResendRes
     public ResendResponseNoResend fromJson(JsonReader reader) throws IOException {
         String streamId = reader.nextString();
         int streamPartition = reader.nextInt();
-        String subId = reader.nextString();
-        return new ResendResponseNoResend(streamId, streamPartition, subId);
+        String requestId = reader.nextString();
+        return new ResendResponseNoResend(streamId, streamPartition, requestId);
     }
 
     @Override
@@ -22,7 +22,7 @@ public class ResendResponseNoResendAdapter extends ControlLayerAdapter<ResendRes
         writer.value(ResendResponseNoResend.TYPE);
         writer.value(value.getStreamId());
         writer.value(value.getStreamPartition());
-        writer.value(value.getSubId());
+        writer.value(value.getRequestId());
         writer.endArray();
     }
 }

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseResending.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseResending.java
@@ -3,7 +3,7 @@ package com.streamr.client.protocol.control_layer;
 public class ResendResponseResending extends ResendResponse {
     public static final int TYPE = 4;
 
-    public ResendResponseResending(String streamId, int streamPartition, String subId) {
-        super(TYPE, streamId, streamPartition, subId);
+    public ResendResponseResending(String streamId, int streamPartition, String requestId) {
+        super(TYPE, streamId, streamPartition, requestId);
     }
 }

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseResendingAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseResendingAdapter.java
@@ -11,8 +11,8 @@ public class ResendResponseResendingAdapter extends ControlLayerAdapter<ResendRe
     public ResendResponseResending fromJson(JsonReader reader) throws IOException {
         String streamId = reader.nextString();
         int streamPartition = reader.nextInt();
-        String subId = reader.nextString();
-        return new ResendResponseResending(streamId, streamPartition, subId);
+        String requestId = reader.nextString();
+        return new ResendResponseResending(streamId, streamPartition, requestId);
     }
 
     @Override
@@ -22,7 +22,7 @@ public class ResendResponseResendingAdapter extends ControlLayerAdapter<ResendRe
         writer.value(ResendResponseResending.TYPE);
         writer.value(value.getStreamId());
         writer.value(value.getStreamPartition());
-        writer.value(value.getSubId());
+        writer.value(value.getRequestId());
         writer.endArray();
     }
 }

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseResent.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseResent.java
@@ -3,7 +3,7 @@ package com.streamr.client.protocol.control_layer;
 public class ResendResponseResent extends ResendResponse {
     public static final int TYPE = 5;
 
-    public ResendResponseResent(String streamId, int streamPartition, String subId) {
-        super(TYPE, streamId, streamPartition, subId);
+    public ResendResponseResent(String streamId, int streamPartition, String requestId) {
+        super(TYPE, streamId, streamPartition, requestId);
     }
 }

--- a/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseResentAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/ResendResponseResentAdapter.java
@@ -11,8 +11,8 @@ public class ResendResponseResentAdapter extends ControlLayerAdapter<ResendRespo
     public ResendResponseResent fromJson(JsonReader reader) throws IOException {
         String streamId = reader.nextString();
         int streamPartition = reader.nextInt();
-        String subId = reader.nextString();
-        return new ResendResponseResent(streamId, streamPartition, subId);
+        String requestId = reader.nextString();
+        return new ResendResponseResent(streamId, streamPartition, requestId);
     }
 
     @Override
@@ -22,7 +22,7 @@ public class ResendResponseResentAdapter extends ControlLayerAdapter<ResendRespo
         writer.value(ResendResponseResent.TYPE);
         writer.value(value.getStreamId());
         writer.value(value.getStreamPartition());
-        writer.value(value.getSubId());
+        writer.value(value.getRequestId());
         writer.endArray();
     }
 }

--- a/src/main/java/com/streamr/client/protocol/control_layer/UnicastMessage.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/UnicastMessage.java
@@ -5,17 +5,17 @@ import com.streamr.client.protocol.message_layer.StreamMessage;
 public class UnicastMessage extends ControlMessage {
     public static final int TYPE = 1;
 
-    private final String subId;
+    private final String requestId;
     private final StreamMessage msg;
 
-    public UnicastMessage(String subId, StreamMessage msg) {
+    public UnicastMessage(String requestId, StreamMessage msg) {
         super(TYPE);
-        this.subId = subId;
+        this.requestId = requestId;
         this.msg = msg;
     }
 
-    public String getSubId() {
-        return subId;
+    public String getRequestId() {
+        return requestId;
     }
 
     public StreamMessage getStreamMessage() {

--- a/src/main/java/com/streamr/client/protocol/control_layer/UnicastMessageAdapter.java
+++ b/src/main/java/com/streamr/client/protocol/control_layer/UnicastMessageAdapter.java
@@ -13,9 +13,9 @@ public class UnicastMessageAdapter extends ControlLayerAdapter<UnicastMessage> {
 
     @Override
     public UnicastMessage fromJson(JsonReader reader) throws IOException {
-        String subId = reader.nextString();
+        String requestId = reader.nextString();
         StreamMessage streamMessage = streamMessageAdapter.fromJson(reader);
-        return new UnicastMessage(subId, streamMessage);
+        return new UnicastMessage(requestId, streamMessage);
     }
 
     @Override
@@ -23,7 +23,7 @@ public class UnicastMessageAdapter extends ControlLayerAdapter<UnicastMessage> {
         writer.beginArray();
         writer.value(ControlMessage.LATEST_VERSION);
         writer.value(UnicastMessage.TYPE);
-        writer.value(value.getSubId());
+        writer.value(value.getRequestId());
         streamMessageAdapter.toJson(writer, value.getStreamMessage());
         writer.endArray();
     }

--- a/src/main/java/com/streamr/client/subs/BasicSubscription.java
+++ b/src/main/java/com/streamr/client/subs/BasicSubscription.java
@@ -80,6 +80,7 @@ public abstract class BasicSubscription extends Subscription {
         Timer t = new Timer(true);
         String publisherId = msgToQueue.getPublisherId().toLowerCase();
         nbGroupKeyRequestsCalls.put(publisherId, 0);
+        pendingGroupKeyRequests.put(publisherId, t);
         TimerTask request = new TimerTask() {
             @Override
             public void run() {
@@ -99,7 +100,6 @@ public abstract class BasicSubscription extends Subscription {
             }
         };
         t.schedule(request, 0, propagationTimeout);
-        pendingGroupKeyRequests.put(publisherId, t);
         encryptedMsgsQueues.offer(msgToQueue);
     }
 

--- a/src/main/java/com/streamr/client/subs/RealTimeSubscription.java
+++ b/src/main/java/com/streamr/client/subs/RealTimeSubscription.java
@@ -113,7 +113,6 @@ public class RealTimeSubscription extends BasicSubscription {
     @Override
     public void endResend() throws GapDetectedException {
         resending = false;
-        this.handler.done(this);
     }
 
     @Override

--- a/src/main/java/com/streamr/client/subs/Subscription.java
+++ b/src/main/java/com/streamr/client/subs/Subscription.java
@@ -24,6 +24,8 @@ public abstract class Subscription {
     protected final long propagationTimeout;
     protected final long resendTimeout;
 
+    protected final HashSet<String> pendingResendRequests = new HashSet<>();
+
     private State state;
 
     public enum State {
@@ -62,6 +64,18 @@ public abstract class Subscription {
 
     public boolean isSubscribed() {
         return state.equals(State.SUBSCRIBED);
+    }
+
+    public void addPendingResendRequest(String requestId) {
+        pendingResendRequests.add(requestId);
+    }
+
+    public void deletePendingResendRequest(String requestId) {
+        pendingResendRequests.remove(requestId);
+    }
+
+    public boolean noPendingResendRequests() {
+        return pendingResendRequests.isEmpty();
     }
 
     public abstract boolean isResending();

--- a/src/main/java/com/streamr/client/utils/ResendUtil.java
+++ b/src/main/java/com/streamr/client/utils/ResendUtil.java
@@ -1,0 +1,40 @@
+package com.streamr.client.utils;
+
+import com.streamr.client.exceptions.InvalidResendResponseException;
+import com.streamr.client.protocol.control_layer.ResendResponse;
+import com.streamr.client.protocol.control_layer.ResendResponseNoResend;
+import com.streamr.client.protocol.control_layer.ResendResponseResent;
+import com.streamr.client.subs.Subscription;
+
+import java.util.HashMap;
+
+public class ResendUtil {
+    private long counter = 0L;
+    private HashMap<String, Subscription> subForRequestId = new HashMap<>();
+
+    public String generateRequestId() {
+        String requestId = "" + counter;
+        counter++;
+        return requestId;
+    }
+
+    public Subscription getSub(ResendResponse resendResponse) throws InvalidResendResponseException {
+        if (!subForRequestId.containsKey(resendResponse.getRequestId())) {
+            throw new InvalidResendResponseException("No subscription for requestId in this response: " + resendResponse.toJson());
+        }
+        return subForRequestId.get(resendResponse.getRequestId());
+    }
+
+    public void deleteDoneSub(ResendResponse resendResponse) {
+        if (resendResponse.getType() == ResendResponseResent.TYPE || resendResponse.getType() == ResendResponseNoResend.TYPE) {
+            subForRequestId.remove(resendResponse.getRequestId());
+        }
+    }
+
+    public String registerResendForSub(Subscription sub) {
+        String requestId = generateRequestId();
+        subForRequestId.put(requestId, sub);
+        // sub.addpending...
+        return requestId;
+    }
+}

--- a/src/main/java/com/streamr/client/utils/ResendUtil.java
+++ b/src/main/java/com/streamr/client/utils/ResendUtil.java
@@ -12,7 +12,7 @@ public class ResendUtil {
     private long counter = 0L;
     private HashMap<String, Subscription> subForRequestId = new HashMap<>();
 
-    public String generateRequestId() {
+    private String generateRequestId() {
         String requestId = "" + counter;
         counter++;
         return requestId;
@@ -25,8 +25,13 @@ public class ResendUtil {
         return subForRequestId.get(resendResponse.getRequestId());
     }
 
-    public void deleteDoneSub(ResendResponse resendResponse) {
+    public void deleteDoneSub(ResendResponse resendResponse) throws InvalidResendResponseException {
         if (resendResponse.getType() == ResendResponseResent.TYPE || resendResponse.getType() == ResendResponseNoResend.TYPE) {
+            Subscription sub = getSub(resendResponse);
+            sub.deletePendingResendRequest(resendResponse.getRequestId());
+            if (sub.noPendingResendRequests()) {
+                sub.endResend();
+            }
             subForRequestId.remove(resendResponse.getRequestId());
         }
     }
@@ -34,7 +39,7 @@ public class ResendUtil {
     public String registerResendForSub(Subscription sub) {
         String requestId = generateRequestId();
         subForRequestId.put(requestId, sub);
-        // sub.addpending...
+        sub.addPendingResendRequest(requestId);
         return requestId;
     }
 }

--- a/src/test/groovy/com/streamr/client/HistoricalSubscriptionSpec.groovy
+++ b/src/test/groovy/com/streamr/client/HistoricalSubscriptionSpec.groovy
@@ -305,6 +305,7 @@ class HistoricalSubscriptionSpec extends Specification {
         // Cannot decrypt msg2, queues it.
         sub.handleResentMessage(msg2)
         // faking the reception of the group key response
+        Thread.sleep(1000)
         sub.setGroupKeys(msg1.getPublisherId(), (ArrayList<GroupKey>)[groupKey1, groupKey2])
         sub.endResend()
         then:
@@ -361,6 +362,7 @@ class HistoricalSubscriptionSpec extends Specification {
         // Cannot decrypt msg4, queues it.
         sub.handleResentMessage(msg4)
         // faking the reception of the group key response
+        Thread.sleep(1000)
         sub.setGroupKeys(msg3.getPublisherId(), (ArrayList<GroupKey>)[groupKey3])
         sub.setGroupKeys(msg1.getPublisherId(), (ArrayList<GroupKey>)[groupKey1, groupKey2])
         sub.endResend()

--- a/src/test/groovy/com/streamr/client/RealTimeSubscriptionSpec.groovy
+++ b/src/test/groovy/com/streamr/client/RealTimeSubscriptionSpec.groovy
@@ -21,6 +21,8 @@ import javax.crypto.spec.SecretKeySpec
 import javax.xml.bind.DatatypeConverter
 import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Supplier
 
 class RealTimeSubscriptionSpec extends Specification {
     StreamMessageV31 msg = new StreamMessageV31("stream-id", 0, (new Date()).getTime(), 0, "publisherId", "msgChainId",
@@ -327,6 +329,7 @@ class RealTimeSubscriptionSpec extends Specification {
         // Cannot decrypt msg2, queues it.
         sub.handleRealTimeMessage(msg2)
         // faking the reception of the group key response
+        Thread.sleep(1000)
         sub.setGroupKeys(msg1.getPublisherId(), (ArrayList<UnencryptedGroupKey>)[groupKey])
         then:
         callCount == 1
@@ -378,6 +381,7 @@ class RealTimeSubscriptionSpec extends Specification {
         // Cannot decrypt msg4, queues it.
         sub.handleRealTimeMessage(msg4)
         // faking the reception of the group key response
+        Thread.sleep(2000)
         sub.setGroupKeys(msg1.getPublisherId(), (ArrayList<UnencryptedGroupKey>)[groupKey1])
         sub.setGroupKeys(msg3.getPublisherId(), (ArrayList<UnencryptedGroupKey>)[groupKey2])
         then:
@@ -430,11 +434,12 @@ class RealTimeSubscriptionSpec extends Specification {
         sub.handleRealTimeMessage(msg1Pub1)
         sub.handleRealTimeMessage(msg1Pub2)
         sub.handleRealTimeMessage(msg2Pub1)
+        Thread.sleep(1000)
         sub.setGroupKeys(publisher1, (ArrayList<UnencryptedGroupKey>)[groupKey1])
         sub.handleRealTimeMessage(msg3Pub1)
         sub.handleRealTimeMessage(msg2Pub2)
+        Thread.sleep(1000)
         sub.setGroupKeys(publisher2, (ArrayList<UnencryptedGroupKey>)[groupKey2])
-
         then:
         callCount == 2
         received.get(0).getContent() == [foo: 'bar1']

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -64,7 +64,7 @@ class StreamrClientSpec extends Specification {
         when:
         client.receiveMessage(new SubscribeResponse("test-stream", 0))
         then:
-        String requestId = client.getSubId("test-stream", 0)
+        String requestId = "0"
         server.expect(new ResendLastRequest("test-stream", 0, requestId, 10, client.getSessionToken()))
         server.noOtherMessagesReceived()
         when:
@@ -85,7 +85,7 @@ class StreamrClientSpec extends Specification {
         }, new ResendLastOption(10))
         server.expect(new SubscribeRequest("test-stream", 0, client.getSessionToken()))
         client.receiveMessage(new SubscribeResponse("test-stream", 0))
-        String requestId = client.getSubId("test-stream", 0)
+        String requestId = "0"
         then:
         Thread.sleep(retryResendAfter + 200)
         server.expect(new ResendLastRequest("test-stream", 0, requestId, 10, client.getSessionToken()))
@@ -106,7 +106,7 @@ class StreamrClientSpec extends Specification {
         client.receiveMessage(new SubscribeResponse("test-stream", 0))
         client.receiveMessage(new BroadcastMessage(createMsg("test-stream", 0, 0, null, null)))
         client.receiveMessage(new BroadcastMessage(createMsg("test-stream", 2, 0, 1, 0)))
-        String requestId = client.getSubId("test-stream", 0)
+        String requestId = "0"
         Thread.sleep(gapFillTimeout)
         then:
         server.expect(new ResendRangeRequest("test-stream", 0, requestId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
@@ -131,11 +131,12 @@ class StreamrClientSpec extends Specification {
         client.receiveMessage(new SubscribeResponse("test-stream", 0))
         client.receiveMessage(new BroadcastMessage(createMsg("test-stream", 0, 0, null, null)))
         client.receiveMessage(new BroadcastMessage(createMsg("test-stream", 2, 0, 1, 0)))
-        String requestId = client.getSubId("test-stream", 0)
+        String requestId1 = "0"
+        String requestId2 = "1"
         then:
         Thread.sleep(2 * gapFillTimeout + 200)
-        server.expect(new ResendRangeRequest("test-stream", 0, requestId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
-        server.expect(new ResendRangeRequest("test-stream", 0, requestId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
+        server.expect(new ResendRangeRequest("test-stream", 0, requestId1, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
+        server.expect(new ResendRangeRequest("test-stream", 0, requestId2, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
     }
 
     void "client reconnects while publishing if server is temporarily down"() {

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -64,11 +64,11 @@ class StreamrClientSpec extends Specification {
         when:
         client.receiveMessage(new SubscribeResponse("test-stream", 0))
         then:
-        String subId = client.getSubId("test-stream", 0)
-        server.expect(new ResendLastRequest("test-stream", 0, subId, 10, client.getSessionToken()))
+        String requestId = client.getSubId("test-stream", 0)
+        server.expect(new ResendLastRequest("test-stream", 0, requestId, 10, client.getSessionToken()))
         server.noOtherMessagesReceived()
         when:
-        client.receiveMessage(new UnicastMessage(subId, createMsg("test-stream", 0, 0, null, null)))
+        client.receiveMessage(new UnicastMessage(requestId, createMsg("test-stream", 0, 0, null, null)))
         then:
         Thread.sleep(retryResendAfter + 200)
         server.noOtherMessagesReceived()
@@ -85,11 +85,11 @@ class StreamrClientSpec extends Specification {
         }, new ResendLastOption(10))
         server.expect(new SubscribeRequest("test-stream", 0, client.getSessionToken()))
         client.receiveMessage(new SubscribeResponse("test-stream", 0))
-        String subId = client.getSubId("test-stream", 0)
+        String requestId = client.getSubId("test-stream", 0)
         then:
         Thread.sleep(retryResendAfter + 200)
-        server.expect(new ResendLastRequest("test-stream", 0, subId, 10, client.getSessionToken()))
-        server.expect(new ResendLastRequest("test-stream", 0, subId, 10, client.getSessionToken()))
+        server.expect(new ResendLastRequest("test-stream", 0, requestId, 10, client.getSessionToken()))
+        server.expect(new ResendLastRequest("test-stream", 0, requestId, 10, client.getSessionToken()))
         server.noOtherMessagesReceived()
     }
 
@@ -106,13 +106,13 @@ class StreamrClientSpec extends Specification {
         client.receiveMessage(new SubscribeResponse("test-stream", 0))
         client.receiveMessage(new BroadcastMessage(createMsg("test-stream", 0, 0, null, null)))
         client.receiveMessage(new BroadcastMessage(createMsg("test-stream", 2, 0, 1, 0)))
-        String subId = client.getSubId("test-stream", 0)
+        String requestId = client.getSubId("test-stream", 0)
         Thread.sleep(gapFillTimeout)
         then:
-        server.expect(new ResendRangeRequest("test-stream", 0, subId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
+        server.expect(new ResendRangeRequest("test-stream", 0, requestId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
         when:
-        client.receiveMessage(new UnicastMessage(subId, createMsg("test-stream", 1, 0, 0, 0)))
-        client.receiveMessage(new ResendResponseResent("test-stream", 0, subId))
+        client.receiveMessage(new UnicastMessage(requestId, createMsg("test-stream", 1, 0, 0, 0)))
+        client.receiveMessage(new ResendResponseResent("test-stream", 0, requestId))
         then:
         Thread.sleep(gapFillTimeout + 200)
         server.noOtherMessagesReceived()
@@ -131,11 +131,11 @@ class StreamrClientSpec extends Specification {
         client.receiveMessage(new SubscribeResponse("test-stream", 0))
         client.receiveMessage(new BroadcastMessage(createMsg("test-stream", 0, 0, null, null)))
         client.receiveMessage(new BroadcastMessage(createMsg("test-stream", 2, 0, 1, 0)))
-        String subId = client.getSubId("test-stream", 0)
+        String requestId = client.getSubId("test-stream", 0)
         then:
         Thread.sleep(2 * gapFillTimeout + 200)
-        server.expect(new ResendRangeRequest("test-stream", 0, subId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
-        server.expect(new ResendRangeRequest("test-stream", 0, subId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
+        server.expect(new ResendRangeRequest("test-stream", 0, requestId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
+        server.expect(new ResendRangeRequest("test-stream", 0, requestId, new MessageRef(0, 1), new MessageRef(1, 0), "", "", client.getSessionToken()))
     }
 
     void "client reconnects while publishing if server is temporarily down"() {

--- a/src/test/groovy/com/streamr/client/protocol/ControlMessageAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ControlMessageAdapterSpec.groovy
@@ -46,7 +46,7 @@ class ControlMessageAdapterSpec extends Specification {
     }
     def "UnicastMessage"() {
         String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
-        String json = '[1,1,"subId",'+msgJson+']'
+        String json = '[1,1,"requestId",'+msgJson+']'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:
@@ -70,7 +70,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "ResendResponseResending"() {
-        String json = '[1,4,"streamId",0,"subId"]'
+        String json = '[1,4,"streamId",0,"requestId"]'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:
@@ -78,7 +78,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "ResendResponseResent"() {
-        String json = '[1,5,"streamId",0,"subId"]'
+        String json = '[1,5,"streamId",0,"requestId"]'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:
@@ -86,7 +86,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "ResendResponseNoResend"() {
-        String json = '[1,6,"streamId",0,"subId"]'
+        String json = '[1,6,"streamId",0,"requestId"]'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:
@@ -127,7 +127,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "ResendLastRequest"() {
-        String json = '[1,11,"streamId",0,"subId",4,"sessionToken"]'
+        String json = '[1,11,"streamId",0,"requestId",4,"sessionToken"]'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:
@@ -135,7 +135,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "ResendFromRequest"() {
-        String json = '[1,12,"streamId",0,"subId",[143415425455,0],"publisherId","msgChainId","sessionToken"]'
+        String json = '[1,12,"streamId",0,"requestId",[143415425455,0],"publisherId","msgChainId","sessionToken"]'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:
@@ -143,7 +143,7 @@ class ControlMessageAdapterSpec extends Specification {
         msg.toJson() == json
     }
     def "ResendRangeRequest"() {
-        String json = '[1,13,"streamId",0,"subId",[143415425455,0],[14341542564555,7],"publisherId","msgChainId","sessionToken"]'
+        String json = '[1,13,"streamId",0,"requestId",[143415425455,0],[14341542564555,7],"publisherId","msgChainId","sessionToken"]'
         when:
         ControlMessage msg = fromJson(adapter, json)
         then:

--- a/src/test/groovy/com/streamr/client/protocol/ResendFromRequestAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ResendFromRequestAdapterSpec.groovy
@@ -32,7 +32,7 @@ class ResendFromRequestAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String json = '[1,12,"streamId",0,"subId",[143415425455,0],"publisherId","msgChainId","sessionToken"]'
+		String json = '[1,12,"streamId",0,"requestId",[143415425455,0],"publisherId","msgChainId","sessionToken"]'
 
 		when:
 		ResendFromRequest msg = toMsg(adapter, json)
@@ -40,7 +40,7 @@ class ResendFromRequestAdapterSpec extends Specification {
 		then:
 		msg.getStreamId() == "streamId"
 		msg.getStreamPartition() == 0
-		msg.getSubId() == "subId"
+		msg.getRequestId() == "requestId"
 		msg.getFromMsgRef().getTimestamp() == 143415425455
 		msg.getFromMsgRef().getSequenceNumber() == 0
 		msg.getPublisherId() == "publisherId"
@@ -49,7 +49,7 @@ class ResendFromRequestAdapterSpec extends Specification {
 	}
 
 	void "fromJson (null fields)"() {
-		String json = '[1,12,"streamId",0,"subId",[143415425455,0],null,null,null]'
+		String json = '[1,12,"streamId",0,"requestId",[143415425455,0],null,null,null]'
 
 		when:
 		ResendFromRequest msg = toMsg(adapter, json)
@@ -57,7 +57,7 @@ class ResendFromRequestAdapterSpec extends Specification {
 		then:
 		msg.getStreamId() == "streamId"
 		msg.getStreamPartition() == 0
-		msg.getSubId() == "subId"
+		msg.getRequestId() == "requestId"
 		msg.getFromMsgRef().getTimestamp() == 143415425455
 		msg.getFromMsgRef().getSequenceNumber() == 0
 		msg.getPublisherId() == null
@@ -67,23 +67,23 @@ class ResendFromRequestAdapterSpec extends Specification {
 
 	void "toJson"() {
 		MessageRef from = new MessageRef(143415425455L, 0L)
-		ResendFromRequest request = new ResendFromRequest("streamId", 0, "subId", from, "publisherId", "msgChainId", "sessionToken")
+		ResendFromRequest request = new ResendFromRequest("streamId", 0, "requestId", from, "publisherId", "msgChainId", "sessionToken")
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,12,"streamId",0,"subId",[143415425455,0],"publisherId","msgChainId","sessionToken"]'
+		buffer.readString(utf8) == '[1,12,"streamId",0,"requestId",[143415425455,0],"publisherId","msgChainId","sessionToken"]'
 	}
 
 	void "toJson (null fields)"() {
 		MessageRef from = new MessageRef(143415425455L, 0L)
-		ResendFromRequest request = new ResendFromRequest("streamId", 0, "subId", from, null, null, null)
+		ResendFromRequest request = new ResendFromRequest("streamId", 0, "requestId", from, null, null, null)
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,12,"streamId",0,"subId",[143415425455,0],null,null,null]'
+		buffer.readString(utf8) == '[1,12,"streamId",0,"requestId",[143415425455,0],null,null,null]'
 	}
 }

--- a/src/test/groovy/com/streamr/client/protocol/ResendLastRequestAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ResendLastRequestAdapterSpec.groovy
@@ -31,7 +31,7 @@ class ResendLastRequestAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String json = '[1,11,"streamId",0,"subId",4,"sessionToken"]'
+		String json = '[1,11,"streamId",0,"requestId",4,"sessionToken"]'
 
 		when:
 		ResendLastRequest msg = toMsg(adapter, json)
@@ -39,13 +39,13 @@ class ResendLastRequestAdapterSpec extends Specification {
 		then:
 		msg.getStreamId() == "streamId"
 		msg.getStreamPartition() == 0
-		msg.getSubId() == "subId"
+		msg.getRequestId() == "requestId"
 		msg.getNumberLast() == 4
 		msg.getSessionToken() == "sessionToken"
 	}
 
 	void "fromJson (null session token)"() {
-		String json = '[1,11,"streamId",0,"subId",4,null]'
+		String json = '[1,11,"streamId",0,"requestId",4,null]'
 
 		when:
 		ResendLastRequest msg = toMsg(adapter, json)
@@ -53,28 +53,28 @@ class ResendLastRequestAdapterSpec extends Specification {
 		then:
 		msg.getStreamId() == "streamId"
 		msg.getStreamPartition() == 0
-		msg.getSubId() == "subId"
+		msg.getRequestId() == "requestId"
 		msg.getNumberLast() == 4
 		msg.getSessionToken() == null
 	}
 
 	void "toJson"() {
-		ResendLastRequest request = new ResendLastRequest("streamId", 0, "subId", 4, "sessionToken")
+		ResendLastRequest request = new ResendLastRequest("streamId", 0, "requestId", 4, "sessionToken")
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,11,"streamId",0,"subId",4,"sessionToken"]'
+		buffer.readString(utf8) == '[1,11,"streamId",0,"requestId",4,"sessionToken"]'
 	}
 
 	void "toJson (null session token)"() {
-		ResendLastRequest request = new ResendLastRequest("streamId", 0, "subId", 4, null)
+		ResendLastRequest request = new ResendLastRequest("streamId", 0, "requestId", 4, null)
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,11,"streamId",0,"subId",4,null]'
+		buffer.readString(utf8) == '[1,11,"streamId",0,"requestId",4,null]'
 	}
 }

--- a/src/test/groovy/com/streamr/client/protocol/ResendRangeRequestAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ResendRangeRequestAdapterSpec.groovy
@@ -32,7 +32,7 @@ class ResendRangeRequestAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String json = '[1,13,"streamId",0,"subId",[143415425455,0],[14341542564555,7],"publisherId","msgChainId","sessionToken"]'
+		String json = '[1,13,"streamId",0,"requestId",[143415425455,0],[14341542564555,7],"publisherId","msgChainId","sessionToken"]'
 
 		when:
 		ResendRangeRequest msg = toMsg(adapter, json)
@@ -40,7 +40,7 @@ class ResendRangeRequestAdapterSpec extends Specification {
 		then:
 		msg.getStreamId() == "streamId"
 		msg.getStreamPartition() == 0
-		msg.getSubId() == "subId"
+		msg.getRequestId() == "requestId"
 		msg.getFromMsgRef().getTimestamp() == 143415425455
 		msg.getFromMsgRef().getSequenceNumber() == 0
 		msg.getToMsgRef().getTimestamp() == 14341542564555
@@ -51,7 +51,7 @@ class ResendRangeRequestAdapterSpec extends Specification {
 	}
 
 	void "fromJson (null fields)"() {
-		String json = '[1,13,"streamId",0,"subId",[143415425455,0],[14341542564555,7],null,null,null]'
+		String json = '[1,13,"streamId",0,"requestId",[143415425455,0],[14341542564555,7],null,null,null]'
 
 		when:
 		ResendRangeRequest msg = toMsg(adapter, json)
@@ -59,7 +59,7 @@ class ResendRangeRequestAdapterSpec extends Specification {
 		then:
 		msg.getStreamId() == "streamId"
 		msg.getStreamPartition() == 0
-		msg.getSubId() == "subId"
+		msg.getRequestId() == "requestId"
 		msg.getFromMsgRef().getTimestamp() == 143415425455
 		msg.getFromMsgRef().getSequenceNumber() == 0
 		msg.getToMsgRef().getTimestamp() == 14341542564555
@@ -70,7 +70,7 @@ class ResendRangeRequestAdapterSpec extends Specification {
 	}
 
 	void "fromJson (from > to)"() {
-		String json = '[1,13,"streamId",0,"subId",[143415425455,0],[143415425000,0],"publisherId","msgChainId","sessionToken"]'
+		String json = '[1,13,"streamId",0,"requestId",[143415425455,0],[143415425000,0],"publisherId","msgChainId","sessionToken"]'
 
 		when:
 		ResendRangeRequest msg = toMsg(adapter, json)
@@ -78,28 +78,28 @@ class ResendRangeRequestAdapterSpec extends Specification {
 		then:
 		thrown(IllegalArgumentException)
 	}
-	
+
 	void "toJson"() {
 		MessageRef from = new MessageRef(143415425455L, 0L)
 		MessageRef to = new MessageRef(14341542564555L, 7L)
-		ResendRangeRequest request = new ResendRangeRequest("streamId", 0, "subId", from, to, "publisherId", "msgChainId", "sessionToken")
+		ResendRangeRequest request = new ResendRangeRequest("streamId", 0, "requestId", from, to, "publisherId", "msgChainId", "sessionToken")
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,13,"streamId",0,"subId",[143415425455,0],[14341542564555,7],"publisherId","msgChainId","sessionToken"]'
+		buffer.readString(utf8) == '[1,13,"streamId",0,"requestId",[143415425455,0],[14341542564555,7],"publisherId","msgChainId","sessionToken"]'
 	}
 
 	void "toJson (null fields)"() {
 		MessageRef from = new MessageRef(143415425455L, 0L)
 		MessageRef to = new MessageRef(14341542564555L, 7L)
-		ResendRangeRequest request = new ResendRangeRequest("streamId", 0, "subId", from, to, null, null, null)
+		ResendRangeRequest request = new ResendRangeRequest("streamId", 0, "requestId", from, to, null, null, null)
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,13,"streamId",0,"subId",[143415425455,0],[14341542564555,7],null,null,null]'
+		buffer.readString(utf8) == '[1,13,"streamId",0,"requestId",[143415425455,0],[14341542564555,7],null,null,null]'
 	}
 }

--- a/src/test/groovy/com/streamr/client/protocol/ResendResponseNoResendAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ResendResponseNoResendAdapterSpec.groovy
@@ -31,7 +31,7 @@ class ResendResponseNoResendAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String json = '[1,6,"streamId",0,"subId"]'
+		String json = '[1,6,"streamId",0,"requestId"]'
 
 		when:
 		ResendResponseNoResend msg = toMsg(adapter, json)
@@ -39,16 +39,16 @@ class ResendResponseNoResendAdapterSpec extends Specification {
 		then:
 		msg.streamId == "streamId"
 		msg.streamPartition == 0
-		msg.subId == "subId"
+		msg.requestId == "requestId"
 	}
 
 	void "toJson"() {
-		ResendResponseNoResend request = new ResendResponseNoResend("streamId", 0, "subId")
+		ResendResponseNoResend request = new ResendResponseNoResend("streamId", 0, "requestId")
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,6,"streamId",0,"subId"]'
+		buffer.readString(utf8) == '[1,6,"streamId",0,"requestId"]'
 	}
 }

--- a/src/test/groovy/com/streamr/client/protocol/ResendResponseResendingAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ResendResponseResendingAdapterSpec.groovy
@@ -31,7 +31,7 @@ class ResendResponseResendingAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String json = '[1,4,"streamId",0,"subId"]'
+		String json = '[1,4,"streamId",0,"requestId"]'
 
 		when:
 		ResendResponseResending msg = toMsg(adapter, json)
@@ -39,16 +39,16 @@ class ResendResponseResendingAdapterSpec extends Specification {
 		then:
 		msg.streamId == "streamId"
 		msg.streamPartition == 0
-		msg.subId == "subId"
+		msg.requestId == "requestId"
 	}
 
 	void "toJson"() {
-		ResendResponseResending request = new ResendResponseResending("streamId", 0, "subId")
+		ResendResponseResending request = new ResendResponseResending("streamId", 0, "requestId")
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,4,"streamId",0,"subId"]'
+		buffer.readString(utf8) == '[1,4,"streamId",0,"requestId"]'
 	}
 }

--- a/src/test/groovy/com/streamr/client/protocol/ResendResponseResentAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ResendResponseResentAdapterSpec.groovy
@@ -31,7 +31,7 @@ class ResendResponseResentAdapterSpec extends Specification {
 	}
 
 	void "fromJson"() {
-		String json = '[1,5,"streamId",0,"subId"]'
+		String json = '[1,5,"streamId",0,"requestId"]'
 
 		when:
 		ResendResponseResent msg = toMsg(adapter, json)
@@ -39,16 +39,16 @@ class ResendResponseResentAdapterSpec extends Specification {
 		then:
 		msg.streamId == "streamId"
 		msg.streamPartition == 0
-		msg.subId == "subId"
+		msg.requestId == "requestId"
 	}
 
 	void "toJson"() {
-		ResendResponseResent request = new ResendResponseResent("streamId", 0, "subId")
+		ResendResponseResent request = new ResendResponseResent("streamId", 0, "requestId")
 
 		when:
 		adapter.toJson(buffer, request)
 
 		then:
-		buffer.readString(utf8) == '[1,5,"streamId",0,"subId"]'
+		buffer.readString(utf8) == '[1,5,"streamId",0,"requestId"]'
 	}
 }

--- a/src/test/groovy/com/streamr/client/protocol/UnicastMessageAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/UnicastMessageAdapterSpec.groovy
@@ -34,13 +34,13 @@ class UnicastMessageAdapterSpec extends Specification {
 
 	void "fromJson"() {
 		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
-		String json = '[1,1,"subId",'+msgJson+']'
+		String json = '[1,1,"requestId",'+msgJson+']'
 
 		when:
 		UnicastMessage msg = toMsg(adapter, json)
 
 		then:
-		msg.getSubId() == "subId"
+		msg.getRequestId() == "requestId"
 		msg.getStreamMessage() instanceof StreamMessage
 	}
 
@@ -48,13 +48,13 @@ class UnicastMessageAdapterSpec extends Specification {
 		StreamMessageV31 msg = new StreamMessageV31(
 				"7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, "publisherId", "1", 1528228170000L, 0,
 				StreamMessage.ContentType.CONTENT_TYPE_JSON, StreamMessage.EncryptionType.NONE, '{"hello":"world"}', StreamMessage.SignatureType.SIGNATURE_TYPE_ETH, "signature")
-		UnicastMessage unicastMessage = new UnicastMessage("subId", msg)
+		UnicastMessage unicastMessage = new UnicastMessage("requestId", msg)
 		String msgJson = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
 
 		when:
 		adapter.toJson(buffer, unicastMessage)
 
 		then:
-		buffer.readString(utf8) == '[1,1,"subId",'+msgJson+']'
+		buffer.readString(utf8) == '[1,1,"requestId",'+msgJson+']'
 	}
 }


### PR DESCRIPTION
Replicate behaviour in the Javascript client. Fixes `resending` state in `Subscription` (must be set to `false` only when ALL currently pending resends are finished).