### PR TITLE
CORE-1912: websocketclient objects are not reuseable

### DIFF
--- a/.idea/modules/streamr-client-java.iml
+++ b/.idea/modules/streamr-client-java.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="streamr-client-java" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.streamr" external.system.module.version="1.2.4" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="streamr-client-java" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.streamr" external.system.module.version="1.3.4" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">

--- a/.idea/modules/streamr-client-java_integrationTest.iml
+++ b/.idea/modules/streamr-client-java_integrationTest.iml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="streamr-client-java:integrationTest" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.streamr" external.system.module.type="sourceSet" external.system.module.version="1.2.4" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="streamr-client-java:integrationTest" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.streamr" external.system.module.type="sourceSet" external.system.module.version="1.3.4" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="Spring" name="Spring">
       <configuration />
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
-    <output-test url="file://$MODULE_DIR$/../../out/test/classes" />
+    <output-test url="file://$MODULE_DIR$/../../build/classes/integrationTest" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../src/integrationTest">
       <sourceFolder url="file://$MODULE_DIR$/../../src/integrationTest/groovy" isTestSource="true" />
@@ -23,7 +23,7 @@
     <orderEntry type="library" name="Gradle: cglib:cglib:3.2.10" level="project" />
     <orderEntry type="library" name="Gradle: org.objenesis:objenesis:3.0.1" level="project" />
     <orderEntry type="library" name="Gradle: org.ethereum:ethereumj-core:1.11.0-RELEASE" level="project" />
-    <orderEntry type="library" name="Gradle: org.java-websocket:Java-WebSocket:1.3.8" level="project" />
+    <orderEntry type="library" name="Gradle: org.java-websocket:Java-WebSocket:1.4.1" level="project" />
     <orderEntry type="library" name="Gradle: org.cache2k:cache2k-api:1.2.1.Final" level="project" />
     <orderEntry type="library" name="Gradle: org.cache2k:cache2k-core:1.2.1.Final" level="project" />
     <orderEntry type="library" name="Gradle: org.spockframework:spock-core:1.1-groovy-2.4" level="project" />
@@ -70,7 +70,7 @@
     <orderEntry type="library" name="Gradle: org.jetbrains:annotations:13.0" level="project" />
     <orderEntry type="library" name="Gradle: commons-codec:commons-codec:1.10" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.commons:commons-lang3:3.4" level="project" />
-    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.20" level="project" />
+    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" name="Gradle: commons-logging:commons-logging:1.2" level="project" />
   </component>
 </module>

--- a/.idea/modules/streamr-client-java_main.iml
+++ b/.idea/modules/streamr-client-java_main.iml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="streamr-client-java:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.streamr" external.system.module.type="sourceSet" external.system.module.version="1.2.4" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="streamr-client-java:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.streamr" external.system.module.type="sourceSet" external.system.module.version="1.3.4" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="Spring" name="Spring">
       <configuration />
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
-    <output url="file://$MODULE_DIR$/../../out/production/classes" />
+    <output url="file://$MODULE_DIR$/../../build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../src/main">
       <sourceFolder url="file://$MODULE_DIR$/../../src/main/java" isTestSource="false" />
@@ -23,7 +23,7 @@
     <orderEntry type="library" name="Gradle: cglib:cglib:3.2.10" level="project" />
     <orderEntry type="library" name="Gradle: org.objenesis:objenesis:3.0.1" level="project" />
     <orderEntry type="library" name="Gradle: org.ethereum:ethereumj-core:1.11.0-RELEASE" level="project" />
-    <orderEntry type="library" name="Gradle: org.java-websocket:Java-WebSocket:1.3.8" level="project" />
+    <orderEntry type="library" name="Gradle: org.java-websocket:Java-WebSocket:1.4.1" level="project" />
     <orderEntry type="library" name="Gradle: org.cache2k:cache2k-api:1.2.1.Final" level="project" />
     <orderEntry type="library" name="Gradle: org.cache2k:cache2k-core:1.2.1.Final" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.logging.log4j:log4j-api:2.7" level="project" />
@@ -46,6 +46,7 @@
     <orderEntry type="library" name="Gradle: org.iq80.leveldb:leveldb:0.7" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-context:4.3.19.RELEASE" level="project" />
     <orderEntry type="library" name="Gradle: org.xerial.snappy:snappy-java:1.1.4" level="project" />
+    <orderEntry type="library" name="Gradle: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.ant:ant-launcher:1.10.3" level="project" />
     <orderEntry type="library" name="Gradle: ch.qos.logback:logback-core:1.1.7" level="project" />
     <orderEntry type="library" name="Gradle: com.cedarsoftware:json-io:2.4.1" level="project" />
@@ -56,7 +57,6 @@
     <orderEntry type="library" name="Gradle: com.google.errorprone:error_prone_annotations:2.1.3" level="project" />
     <orderEntry type="library" name="Gradle: com.google.j2objc:j2objc-annotations:1.1" level="project" />
     <orderEntry type="library" name="Gradle: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
-    <orderEntry type="library" name="Gradle: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Gradle: org.iq80.leveldb:leveldb-api:0.7" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-aop:4.3.19.RELEASE" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-beans:4.3.19.RELEASE" level="project" />
@@ -65,10 +65,10 @@
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.2.60" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.2.60" level="project" />
-    <orderEntry type="library" name="Gradle: org.jetbrains:annotations:13.0" level="project" />
     <orderEntry type="library" name="Gradle: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" name="Gradle: org.jetbrains:annotations:13.0" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.commons:commons-lang3:3.4" level="project" />
-    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.20" level="project" />
+    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" name="Gradle: commons-logging:commons-logging:1.2" level="project" />
   </component>
 </module>

--- a/.idea/modules/streamr-client-java_test.iml
+++ b/.idea/modules/streamr-client-java_test.iml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="streamr-client-java:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.streamr" external.system.module.type="sourceSet" external.system.module.version="1.2.4" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="streamr-client-java:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.streamr" external.system.module.type="sourceSet" external.system.module.version="1.3.4" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="Spring" name="Spring">
       <configuration />
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
-    <output-test url="file://$MODULE_DIR$/../../out/test/classes" />
+    <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../src/test">
       <sourceFolder url="file://$MODULE_DIR$/../../src/test/groovy" isTestSource="true" />
@@ -23,7 +23,7 @@
     <orderEntry type="library" name="Gradle: cglib:cglib:3.2.10" level="project" />
     <orderEntry type="library" name="Gradle: org.objenesis:objenesis:3.0.1" level="project" />
     <orderEntry type="library" name="Gradle: org.ethereum:ethereumj-core:1.11.0-RELEASE" level="project" />
-    <orderEntry type="library" name="Gradle: org.java-websocket:Java-WebSocket:1.3.8" level="project" />
+    <orderEntry type="library" name="Gradle: org.java-websocket:Java-WebSocket:1.4.1" level="project" />
     <orderEntry type="library" name="Gradle: org.cache2k:cache2k-api:1.2.1.Final" level="project" />
     <orderEntry type="library" name="Gradle: org.cache2k:cache2k-core:1.2.1.Final" level="project" />
     <orderEntry type="library" name="Gradle: org.spockframework:spock-core:1.1-groovy-2.4" level="project" />
@@ -70,7 +70,7 @@
     <orderEntry type="library" name="Gradle: org.jetbrains:annotations:13.0" level="project" />
     <orderEntry type="library" name="Gradle: commons-codec:commons-codec:1.10" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.commons:commons-lang3:3.4" level="project" />
-    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.20" level="project" />
+    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" name="Gradle: commons-logging:commons-logging:1.2" level="project" />
   </component>
   <component name="TestModuleProperties" production-module="streamr-client-java_main" />

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -207,7 +207,7 @@ public class StreamrClient extends StreamrRESTClient {
                 e.printStackTrace();
                 Thread.currentThread().interrupt();
             }
-        });
+        }, "sleepThenReconnectThread-" + System.currentTimeMillis());
         currentReconnectThread.start();
     }
 

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -447,7 +447,14 @@ public class StreamrClient extends StreamrRESTClient {
 
     public void publish(Stream stream, Map<String, Object> payload, Date timestamp, String partitionKey, UnencryptedGroupKey newGroupKey) {
         if (!getState().equals(ReadyState.OPEN)) {
-            connect();
+            if (!userWantsToConnect) {
+                connect();
+            } else {
+                waitForState(ReadyState.OPEN);
+                if (!getState().equals(ReadyState.OPEN)) {
+                    throw new RuntimeException("Was unable to publish because readyState never changed to OPEN");
+                }
+            }
         }
         if (newGroupKey != null) {
             options.getEncryptionOptions().getPublisherGroupKeys().put(stream.getId(), newGroupKey);


### PR DESCRIPTION
- IDEA file commits are intentional.
- Added test that reproduces the stack trace found on the latest comment of Jira ticket CORE-1912.
- Added the corresponding fix to method `publish`. When we are not connected, it will only `connect()` if `!userWantsToConnect`, i.e., we don't have an ongoing reconnect thread in the works. 