### PR TITLE
JAVA-8: Re-write reconnection logic

### DIFF
--- a/src/integrationTest/groovy/com/streamr/client/StreamrWebsocketSpec.groovy
+++ b/src/integrationTest/groovy/com/streamr/client/StreamrWebsocketSpec.groovy
@@ -328,7 +328,7 @@ class StreamrWebsocketSpec extends StreamrIntegrationSpecification {
 
 		when:
 		client.publish(stream, [i: 1])
-		Thread.sleep(5000) // wait to land in storage
+		Thread.sleep(6000) // wait to land in storage
 		// Subscribe to the stream
 		sub = client.subscribe(stream, 0, new MessageHandler() {
 			@Override
@@ -337,7 +337,7 @@ class StreamrWebsocketSpec extends StreamrIntegrationSpecification {
 			}
 		}, new ResendLastOption(1))
 
-		Thread.sleep(5000)
+		Thread.sleep(6000)
 
 		then:
 		received
@@ -389,7 +389,7 @@ class StreamrWebsocketSpec extends StreamrIntegrationSpecification {
 		for (int i = 0; i <= 10; i++) {
 			client.publish(stream, [i: i])
 		}
-		Thread.sleep(5000) // wait to land in storage
+		Thread.sleep(6000) // wait to land in storage
 
 		int i = 0
 		// Subscribe to the stream
@@ -436,7 +436,7 @@ class StreamrWebsocketSpec extends StreamrIntegrationSpecification {
 				resendFromDate = new Date()
 			}
 		}
-		Thread.sleep(5000) // wait to land in storage
+		Thread.sleep(6000) // wait to land in storage
 
 		int i = 0
 		// Subscribe to the stream
@@ -487,7 +487,7 @@ class StreamrWebsocketSpec extends StreamrIntegrationSpecification {
 				resendToDate = new Date(date.getTime() - 1)
 			}
 		}
-		Thread.sleep(5000) // wait to land in storage
+		Thread.sleep(6000) // wait to land in storage
 
 		int i = 0
 		// Subscribe to the stream

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -293,11 +293,12 @@ public class StreamrClient extends StreamrRESTClient {
     }
 
     private void waitForState(ReadyState target) {
-        long iterations = (options.getReconnectRetryInterval()  + options.getConnectionTimeoutMillis() + 500) / 100;
-        while (getState() != target && iterations > 0) {
+        long maxWaitTime = options.getReconnectRetryInterval() + options.getConnectionTimeoutMillis() + 500;
+        long timeWaited = 0;
+        while (getState() != target && timeWaited < maxWaitTime) {
             try {
                 Thread.sleep(100);
-                iterations--;
+                timeWaited += 100;
             } catch (InterruptedException e) {
                 // ignore
             }

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -196,8 +196,8 @@ public class StreamrClient extends StreamrRESTClient {
             return;
         }
 
-        if (!keepConnected) {
-            synchronized (stateChangeLock) {
+        synchronized (stateChangeLock) {
+            if (!keepConnected) {
                 keepConnected = true;
                 log.info("Connecting to " + options.getWebsocketApiUrl() + "...");
                 executorService.scheduleAtFixedRate(() -> {

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -58,7 +58,7 @@ public class StreamrClient extends StreamrRESTClient {
     private ErrorMessageHandler errorMessageHandler;
     private boolean keepConnected = false;
     private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-    private final Object lock = new Object();
+    private final Object stateChangeLock = new Object();
 
     public StreamrClient(StreamrClientOptions options) {
         super(options);
@@ -197,7 +197,7 @@ public class StreamrClient extends StreamrRESTClient {
         }
 
         if (!keepConnected) {
-            synchronized (lock) {
+            synchronized (stateChangeLock) {
                 keepConnected = true;
                 log.info("Connecting to " + options.getWebsocketApiUrl() + "...");
                 executorService.scheduleAtFixedRate(() -> {
@@ -275,7 +275,7 @@ public class StreamrClient extends StreamrRESTClient {
             return;
         }
 
-        synchronized (lock) {
+        synchronized (stateChangeLock) {
             keepConnected = false;
         }
         waitForState(ReadyState.CLOSED);

--- a/src/test/groovy/com/streamr/client/HistoricalSubscriptionSpec.groovy
+++ b/src/test/groovy/com/streamr/client/HistoricalSubscriptionSpec.groovy
@@ -318,7 +318,7 @@ class HistoricalSubscriptionSpec extends Specification {
         sub.endResend()
 
         then:
-        new PollingConditions().within(10) {
+        new PollingConditions().within(20) {
             callCount == 1
         }
         received1.getContent() == [foo: 'bar1']

--- a/src/test/groovy/com/streamr/client/HistoricalSubscriptionSpec.groovy
+++ b/src/test/groovy/com/streamr/client/HistoricalSubscriptionSpec.groovy
@@ -314,6 +314,7 @@ class HistoricalSubscriptionSpec extends Specification {
         // Cannot decrypt msg2, queues it.
         sub.handleResentMessage(msg2)
         // faking the reception of the group key response
+        Thread.sleep(100)
         sub.setGroupKeys(msg1.getPublisherId(), (ArrayList<GroupKey>)[groupKey1, groupKey2])
         sub.endResend()
 

--- a/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientSpec.groovy
@@ -38,6 +38,8 @@ class StreamrClientSpec extends Specification {
 
         EncryptionOptions encryptionOptions = new EncryptionOptions(new HashMap<>(), new HashMap<>(), true, null, null, false)
         StreamrClientOptions options = new StreamrClientOptions(new ApiKeyAuthenticationMethod("apikey"), signingOptions, encryptionOptions, server.getWsUrl(), "", gapFillTimeout, retryResendAfter, false)
+        options.reconnectRetryInterval = 1000
+        options.connectionTimeoutMillis = 1000
         client = new TestingStreamrClient(options)
         client.connect()
     }
@@ -216,9 +218,6 @@ class StreamrClientSpec extends Specification {
 
     void "subscribed client reconnects if server is temporarily down"() {
         when:
-        client.options.reconnectRetryInterval = 1000
-        client.options.connectionTimeoutMillis = 1000
-
         Stream stream = new Stream("", "")
         stream.setId("test-stream")
         stream.setPartitions(1)


### PR DESCRIPTION
Re-write the reconnection logic so that there is a task that gets executed every `reconnectRetryInterval` milliseconds. This task makes sure that the intended state `keepConnected` of StreamrClient is followed by either opening or closing the underlying websocket connection.