### PR TITLE
Update versions in url

### DIFF
--- a/src/main/java/com/streamr/client/options/StreamrClientOptions.java
+++ b/src/main/java/com/streamr/client/options/StreamrClientOptions.java
@@ -12,7 +12,7 @@ public class StreamrClientOptions {
     private SigningOptions signingOptions = SigningOptions.getDefault();
     private EncryptionOptions encryptionOptions = EncryptionOptions.getDefault();
     private boolean publishSignedMsgs = false;
-    private String websocketApiUrl = "wss://www.streamr.com/api/v1/ws?controlLayerVersion=1&messageLayerVersion=30";
+    private String websocketApiUrl = "wss://www.streamr.com/api/v1/ws?controlLayerVersion=2&messageLayerVersion=32";
     private String restApiUrl = "https://www.streamr.com/api/v1";
     private long connectionTimeoutMillis = 10 * 1000;
     private long reconnectRetryInterval = 10 * 1000;

--- a/src/main/java/com/streamr/client/options/StreamrClientOptions.java
+++ b/src/main/java/com/streamr/client/options/StreamrClientOptions.java
@@ -12,7 +12,9 @@ public class StreamrClientOptions {
     private SigningOptions signingOptions = SigningOptions.getDefault();
     private EncryptionOptions encryptionOptions = EncryptionOptions.getDefault();
     private boolean publishSignedMsgs = false;
-    private String websocketApiUrl = "wss://www.streamr.com/api/v1/ws?controlLayerVersion=2&messageLayerVersion=32";
+    private String websocketApiUrl = "wss://www.streamr.com/api/v1/ws" +
+            "?controlLayerVersion=" + ControlMessage.LATEST_VERSION +
+            "&messageLayerVersion=" + StreamMessage.LATEST_VERSION;
     private String restApiUrl = "https://www.streamr.com/api/v1";
     private long connectionTimeoutMillis = 10 * 1000;
     private long reconnectRetryInterval = 10 * 1000;

--- a/src/test/groovy/com/streamr/client/StreamrClientOptionsSpec.groovy
+++ b/src/test/groovy/com/streamr/client/StreamrClientOptionsSpec.groovy
@@ -76,4 +76,11 @@ class StreamrClientOptionsSpec extends Specification {
         then:
         options.getWebsocketApiUrl() == expectedUrl
     }
+
+    void "by default has correct versions in ws url"() {
+        when:
+        StreamrClientOptions options = new StreamrClientOptions()
+        then:
+        options.getWebsocketApiUrl() == "wss://www.streamr.com/api/v1/ws?controlLayerVersion=${ControlMessage.LATEST_VERSION}&messageLayerVersion=${StreamMessage.LATEST_VERSION}"
+    }
 }


### PR DESCRIPTION
Running the following code
```java
import com.streamr.client.MessageHandler;
import com.streamr.client.StreamrClient;
import com.streamr.client.protocol.message_layer.StreamMessage;
import com.streamr.client.rest.Stream;
import com.streamr.client.subs.Subscription;

import java.io.IOException;

public class Main {
    public static void main(String[] args) throws IOException {
        StreamrClient client = new StreamrClient();
        Stream stream = client.getStream("7wa7APtlTq6EC5iTCBy6dw");
        Subscription sub = client.subscribe(stream, new MessageHandler() {

            @Override
            public void onMessage(Subscription sub, StreamMessage message) {
                System.out.println(message.getParsedContent());
            }
        });
    }
}

```

shows that streamr-client-java sends a WS request with controlLayerVersion=1 even though it expects responses from server to be controlLayerVersion=2.