### PR TITLE
NET-66: Can create stream without "name" field

### DIFF
--- a/src/main/java/com/streamr/client/StreamrRESTClient.java
+++ b/src/main/java/com/streamr/client/StreamrRESTClient.java
@@ -138,10 +138,6 @@ public abstract class StreamrRESTClient extends AbstractStreamrClient {
     }
 
     public Stream createStream(Stream stream) throws IOException {
-        if (stream.getName() == null || stream.getName().isEmpty()) {
-            throw new IllegalArgumentException("The stream name must be set!");
-        }
-
         HttpUrl url = HttpUrl.parse(options.getRestApiUrl() + "/streams");
         return post(url, streamJsonAdapter.toJson(stream), streamJsonAdapter);
     }


### PR DESCRIPTION
Name field is optional in POST /stream endpoint, remove the assertion check.