### PR TITLE
NET-104: Remove commons lang 2 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ dependencies {
 	compile group: 'com.squareup.moshi', name: 'moshi-adapters', version: '1.6.0'
 	compile group: 'com.squareup.okio', name: 'okio', version: '2.2.0'
 	compile 'commons-codec:commons-codec:1.6'
-	compile 'commons-lang:commons-lang:2.6'
 	compile 'org.apache.commons:commons-lang3:3.1'
 	compile 'cglib:cglib:3.2.10'
 	compile 'org.objenesis:objenesis:3.0.1'


### PR DESCRIPTION
It's not used and commons lang 3 is available.