### PR TITLE
Fix Travis build: remove bridge_collected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ jobs:
     - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start"
     - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh log -f engine-and-editor broker-node-storage-1 broker-node-no-storage-1 broker-node-no-storage-2 &"
     - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh wait"
-    - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh stop bridge_collected"
     - "./gradlew integrationTest --stacktrace --info"
 #  - stage: Tests
 #    name: Cross-client tests


### PR DESCRIPTION
Currently build is failing because we try to stop a service that doesn't exist.
Bridge_collected was a service in streamr-docker-dev. It was removed from streamr-docker-dev earlier. See https://github.com/streamr-dev/streamr-docker-dev/commit/bd5278fe416f4b2f01758b11ab47088896602b49


