### PR TITLE
Revert "Bump cache2kVersion from 1.6.0.Final to 2.0.0.Final (#107)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ ext {
 	okIoVersion = '2.9.0'
 	commonsLangVersion = '3.11'
 	javaWebSocketVersion = '1.5.1'
-	cache2kVersion = '2.0.0.Final'
+	cache2kVersion = '1.6.0.Final'
 	web3jVersion = '5.0.0'
 	findbugsVersion = '3.0.2'
 	jetbrainsVersion = '17.0.0'

--- a/src/integrationTest/groovy/com/streamr/client/dataunion/DataUnionClientTest.java
+++ b/src/integrationTest/groovy/com/streamr/client/dataunion/DataUnionClientTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.web3j.protocol.http.HttpService;
 @Timeout(value = 11, unit = TimeUnit.MINUTES)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Disabled
 class DataUnionClientTest {
   private static final String DEV_MAINCHAIN_RPC = "http://localhost:8545";
   private static final String DEV_SIDECHAIN_RPC = "http://localhost:8546";


### PR DESCRIPTION
- This reverts commit bfa1fa4a5598cc2f8c772f0a0762ba44b8feadf6.
- Disable DataUnionClienTest now that it is being fixed