### PR TITLE
NET-178: Storage node endpoints

### DIFF
--- a/src/main/java/com/streamr/client/StreamrRESTClient.java
+++ b/src/main/java/com/streamr/client/StreamrRESTClient.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 class StorageNodeInput {
-    String storageNodeAddress;
+    Address storageNodeAddress;
 }
 
 /**
@@ -233,7 +233,7 @@ public abstract class StreamrRESTClient extends AbstractStreamrClient {
         JsonAdapter<List<StorageNodeInput>> adapter = MOSHI.adapter(Types.newParameterizedType(List.class, StorageNodeInput.class));
         List<StorageNodeInput> items = get(url, adapter);
         return items.stream()
-            .map(item -> new StorageNode(new Address(item.storageNodeAddress)))
+            .map(item -> new StorageNode(item.storageNodeAddress))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/streamr/client/StreamrRESTClient.java
+++ b/src/main/java/com/streamr/client/StreamrRESTClient.java
@@ -14,6 +14,12 @@ import okhttp3.*;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class StorageNodeInput {
+    String storageNodeAddress;
+}
 
 /**
  * This class exposes the RESTful API endpoints.
@@ -25,6 +31,7 @@ public abstract class StreamrRESTClient extends AbstractStreamrClient {
     public static final JsonAdapter<UserInfo> userInfoJsonAdapter = MOSHI.adapter(UserInfo.class);
     public static final JsonAdapter<Publishers> publishersJsonAdapter = MOSHI.adapter(Publishers.class);
     public static final JsonAdapter<Subscribers> subscribersJsonAdapter = MOSHI.adapter(Subscribers.class);
+    public static final JsonAdapter<StorageNode> storageNodeJsonAdapter = MOSHI.adapter(StorageNode.class);
     public static final JsonAdapter<List<Stream>> streamListJsonAdapter = MOSHI.adapter(Types.newParameterizedType(List.class, Stream.class));
 
     // private final Publisher publisher;
@@ -101,6 +108,11 @@ public abstract class StreamrRESTClient extends AbstractStreamrClient {
                 .url(url)
                 .post(RequestBody.create(HttpUtils.jsonType, requestBody));
         return executeWithRetry(builder, adapter, retryIfSessionExpired);
+    }
+
+    private <T> T delete(HttpUrl url) throws IOException {
+        Request.Builder builder = new Request.Builder().url(url).delete();
+        return executeWithRetry(builder, null, true);
     }
 
     /*
@@ -204,6 +216,34 @@ public abstract class StreamrRESTClient extends AbstractStreamrClient {
         } catch (ResourceNotFoundException e) {
             return false;
         }
+    }
+
+    public void addStreamToStorageNode(String streamId, StorageNode storageNode) throws IOException {
+        HttpUrl url = getEndpointUrl("streams", streamId, "storageNodes");
+        post(url, storageNodeJsonAdapter.toJson(storageNode), streamJsonAdapter);
+    }
+
+    public void removeStreamToStorageNode(String streamId, StorageNode storageNode) throws IOException {
+        HttpUrl url = getEndpointUrl("streams", streamId, "storageNodes", storageNode.getAddress().toString());
+        delete(url);
+    }
+
+    public List<StorageNode> getStorageNodes(String streamId) throws IOException {
+        HttpUrl url = getEndpointUrl("streams", streamId, "storageNodes");
+        JsonAdapter<List<StorageNodeInput>> adapter = MOSHI.adapter(Types.newParameterizedType(List.class, StorageNodeInput.class));
+        List<StorageNodeInput> items = get(url, adapter);
+        return items.stream()
+            .map(item -> new StorageNode(new Address(item.storageNodeAddress)))
+            .collect(Collectors.toList());
+    }
+
+    public List<StreamPart> getStreamPartsByStorageNode(StorageNode storageNode) throws IOException {
+        HttpUrl url = getEndpointUrl("storageNodes", storageNode.getAddress().toString(), "streams");
+        List<Stream> streams = get(url, streamListJsonAdapter);
+        return streams.stream()
+            .map(stream -> stream.toStreamParts())
+            .flatMap(x -> x.stream())
+            .collect(Collectors.toList());
     }
 
     public void logout() throws IOException {

--- a/src/main/java/com/streamr/client/rest/StorageNode.java
+++ b/src/main/java/com/streamr/client/rest/StorageNode.java
@@ -1,0 +1,15 @@
+package com.streamr.client.rest;
+
+import com.streamr.client.utils.Address;
+
+public class StorageNode {
+    private Address address;
+
+    public StorageNode(Address address) {
+        this.address = address;
+    }
+
+    public Address getAddress() {
+        return this.address;
+    }
+}

--- a/src/main/java/com/streamr/client/rest/Stream.java
+++ b/src/main/java/com/streamr/client/rest/Stream.java
@@ -1,6 +1,8 @@
 package com.streamr.client.rest;
 
 import java.util.Date;
+import java.util.List;
+import java.util.ArrayList;
 
 /*
 {
@@ -130,5 +132,13 @@ public class Stream {
 
     public Date getLastUpdated() {
         return lastUpdated;
+    }
+
+    public List<StreamPart> toStreamParts() {
+        List<StreamPart> result = new ArrayList();
+        for (int i = 0; i < this.partitions; i++) {
+            result.add(new StreamPart(this.id, i));
+        }
+        return result;
     }
 }

--- a/src/main/java/com/streamr/client/rest/StreamPart.java
+++ b/src/main/java/com/streamr/client/rest/StreamPart.java
@@ -1,0 +1,20 @@
+package com.streamr.client.rest;
+
+public class StreamPart {
+
+    String streamId;
+    int streamPartition;
+
+    public StreamPart(String streamId, int streamPartition) {
+        this.streamId = streamId;
+        this.streamPartition = streamPartition;
+    }
+
+    public String getStreamId() {
+        return this.streamId;
+    }
+
+    public int getStreamPartition() {
+        return this.streamPartition;
+    }
+}

--- a/src/main/java/com/streamr/client/utils/Address.java
+++ b/src/main/java/com/streamr/client/utils/Address.java
@@ -38,7 +38,7 @@ public class Address {
         return address;
     }
 
-    static Address createRandom() {
+    public static Address createRandom() {
         byte[] array = new byte[20];
         new Random().nextBytes(array);
         return new Address(array);

--- a/src/main/java/com/streamr/client/utils/Address.java
+++ b/src/main/java/com/streamr/client/utils/Address.java
@@ -2,6 +2,8 @@ package com.streamr.client.utils;
 
 import org.apache.commons.codec.binary.Hex;
 
+import java.util.Random;
+
 /**
  * For making sure that Ethereum addresses are always treated similarly everywhere (e.g. lower-cased)
  */
@@ -34,5 +36,11 @@ public class Address {
     @Override
     public String toString() {
         return address;
+    }
+
+    static Address createRandom() {
+        byte[] array = new byte[20];
+        new Random().nextBytes(array);
+        return new Address(array);
     }
 }

--- a/src/main/java/com/streamr/client/utils/AddressJsonAdapter.java
+++ b/src/main/java/com/streamr/client/utils/AddressJsonAdapter.java
@@ -1,0 +1,21 @@
+package com.streamr.client.utils;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+
+import java.io.IOException;
+
+public class AddressJsonAdapter extends JsonAdapter<Address>{
+
+    @Override 
+    public synchronized Address fromJson(JsonReader reader) throws IOException {
+        return new Address(reader.nextString());
+    }
+
+    @Override 
+    public synchronized void toJson(JsonWriter writer, Address value) throws IOException {
+        writer.value(value.toString());
+    }
+
+}

--- a/src/main/java/com/streamr/client/utils/HttpUtils.java
+++ b/src/main/java/com/streamr/client/utils/HttpUtils.java
@@ -21,6 +21,7 @@ public class HttpUtils {
 
     static public Function<Moshi.Builder, Moshi.Builder> addDefaultAdapters = (builder) -> builder
             .add(Date.class, new StringOrMillisDateJsonAdapter().nullSafe())
+            .add(Address.class, new AddressJsonAdapter().nullSafe())
             .add(BigDecimal.class, new BigDecimalAdapter().nullSafe());
 
     // Thread safe

--- a/src/test/groovy/com/streamr/client/utils/AddressJsonAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/AddressJsonAdapterSpec.groovy
@@ -1,0 +1,45 @@
+package com.streamr.client.utils
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import okio.Buffer
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+
+class TestWrapper {
+    Address address
+
+    TestWrapper(Address address) {
+        this.address = address
+    }
+}
+
+class AddressJsonAdapterSpec extends Specification {
+
+	private static JsonReader toReader(String json) {
+		return JsonReader.of(new Buffer().writeString(json, Charset.forName("UTF-8")))
+	}
+
+    def "Address.fromJson"(String json, Address address) {
+        JsonAdapter<TestWrapper> adapter = HttpUtils.MOSHI.adapter(TestWrapper.class);
+        expect:
+        adapter.fromJson(toReader(json)).address == address
+		where:
+        json | address
+        "{\"address\": \"0x1111111111111111111111111111111111111111\"}" | new Address("0x1111111111111111111111111111111111111111")
+        "{\"address\": null}" | null
+        "{}" | null
+	}
+
+	def "Address.toJson"(Address address, String json) {
+        JsonAdapter<TestWrapper> adapter = HttpUtils.MOSHI.adapter(TestWrapper.class);
+        expect:
+        adapter.toJson(new TestWrapper(address)) == json
+		where:
+        address | json
+        new Address("0x2222222222222222222222222222222222222222") | "{\"address\":\"0x2222222222222222222222222222222222222222\"}"
+        null | "{}"
+	}
+
+}


### PR DESCRIPTION
Added methods to storage node query/modification:

- `addStreamToStorageNode`
- `removeStreamToStorageNode`
- `getStorageNodes`
- `getStreamPartsByStorageNode`

The methods use new entity classes: `StorageNode` and `StreamPart`. Both are currently minimal without any no business logic. We'll add more methods to the classes in the future.

Added also new `AddressJsonAdapter` to support the JSON serialization/deserialization of `Address` class.