### PR TITLE
Address validation and checksum

### DIFF
--- a/src/integrationTest/groovy/com/streamr/client/StreamEndpointsSpec.groovy
+++ b/src/integrationTest/groovy/com/streamr/client/StreamEndpointsSpec.groovy
@@ -9,6 +9,7 @@ import com.streamr.client.rest.StreamConfig
 import com.streamr.client.exceptions.AuthenticationException
 import com.streamr.client.rest.FieldConfig
 import com.streamr.client.rest.UserInfo
+import com.streamr.client.utils.Address
 
 class StreamEndpointsSpec extends StreamrIntegrationSpecification {
 
@@ -163,9 +164,9 @@ class StreamEndpointsSpec extends StreamrIntegrationSpecification {
         Stream proto = new Stream(generateResourceName(), "This stream was created from an integration test")
         Stream createdResult = client.createStream(proto)
         when:
-        List<String> publishers = client.getPublishers(createdResult.id)
+        List<Address> publishers = client.getPublishers(createdResult.id).collect { p -> new Address(p) }
         then:
-        publishers == [client.getPublisherId().toString()]
+        publishers == [client.getPublisherId()]
     }
 
     void "isPublisher()"() {
@@ -183,9 +184,9 @@ class StreamEndpointsSpec extends StreamrIntegrationSpecification {
         Stream proto = new Stream(generateResourceName(), "This stream was created from an integration test")
         Stream createdResult = client.createStream(proto)
         when:
-        List<String> subscribers = client.getSubscribers(createdResult.id)
+        List<String> subscribers = client.getSubscribers(createdResult.id).collect { s -> new Address(s) }
         then:
-        subscribers == [client.getPublisherId().toString()]
+        subscribers == [client.getPublisherId()]
     }
 
     void "isSubscriber()"() {

--- a/src/main/java/com/streamr/client/utils/Address.java
+++ b/src/main/java/com/streamr/client/utils/Address.java
@@ -35,4 +35,10 @@ public class Address {
     public String toString() {
         return address;
     }
+
+    public static Address createRandom() {
+        byte[] array = new byte[20];
+        new Random().nextBytes(array);
+        return new Address(array);
+    }
 }

--- a/src/main/java/com/streamr/client/utils/Address.java
+++ b/src/main/java/com/streamr/client/utils/Address.java
@@ -54,10 +54,4 @@ public class Address {
         new Random().nextBytes(array);
         return new Address(array);
     }
-
-    public static Address createRandom() {
-        byte[] array = new byte[20];
-        new Random().nextBytes(array);
-        return new Address(array);
-    }
 }

--- a/src/main/java/com/streamr/client/utils/Address.java
+++ b/src/main/java/com/streamr/client/utils/Address.java
@@ -1,6 +1,10 @@
 package com.streamr.client.utils;
 
 import org.apache.commons.codec.binary.Hex;
+import org.web3j.crypto.Keys;
+import org.web3j.crypto.WalletUtils;
+
+import java.util.Random;
 
 /**
  * For making sure that Ethereum addresses are always treated similarly everywhere (e.g. lower-cased)
@@ -13,6 +17,9 @@ public class Address {
     }
 
     public Address(String address) {
+        if ((address == null) || !WalletUtils.isValidAddress(address)) {
+            throw new IllegalArgumentException("Invalid Ethereum address: " + address);
+        }
         this.address = address.toLowerCase();
     }
 
@@ -33,7 +40,11 @@ public class Address {
 
     @Override
     public String toString() {
-        return address;
+        return Keys.toChecksumAddress(this.address);
+    }
+
+    public String toLowerCaseString() {
+        return this.address;
     }
 
     public static Address createRandom() {

--- a/src/main/java/com/streamr/client/utils/KeyExchangeUtil.java
+++ b/src/main/java/com/streamr/client/utils/KeyExchangeUtil.java
@@ -184,7 +184,7 @@ public class KeyExchangeUtil {
     }
 
     public static String getKeyExchangeStreamId(Address recipientAddress) {
-        return KEY_EXCHANGE_STREAM_PREFIX + recipientAddress;
+        return KEY_EXCHANGE_STREAM_PREFIX + recipientAddress.toLowerCaseString();
     }
 
     public static boolean isKeyExchangeStreamId(String streamId) {

--- a/src/main/java/com/streamr/client/utils/SigningUtil.java
+++ b/src/main/java/com/streamr/client/utils/SigningUtil.java
@@ -54,7 +54,7 @@ public class SigningUtil {
             StringBuilder sb = new StringBuilder(msg.getStreamId());
             sb.append(msg.getStreamPartition());
             sb.append(msg.getTimestamp());
-            sb.append(msg.getPublisherId());
+            sb.append(msg.getPublisherId().toLowerCaseString());
             sb.append(msg.getSerializedContent());
             return sb.toString();
         } else if (signatureType == StreamMessage.SignatureType.ETH) {
@@ -62,7 +62,7 @@ public class SigningUtil {
             sb.append(msg.getStreamPartition());
             sb.append(msg.getTimestamp());
             sb.append(msg.getSequenceNumber());
-            sb.append(msg.getPublisherId());
+            sb.append(msg.getPublisherId().toLowerCaseString());
             sb.append(msg.getMsgChainId());
             if (msg.getPreviousMessageRef() != null) {
                 sb.append(msg.getPreviousMessageRef().getTimestamp());
@@ -85,7 +85,12 @@ public class SigningUtil {
     }
 
     private static boolean verify(String data, String signature, Address address) throws SignatureException, DecoderException {
-        return recoverAddress(calculateMessageHash(data), signature).equals(address);
+        System.out.println("data=" + data);
+        System.out.println("signature=" + signature);
+        System.out.println("address=" + address);
+        Address foobar = recoverAddress(calculateMessageHash(data), signature);
+        System.out.println(foobar + " vs " + address + " " + foobar.equals(address));
+        return foobar.equals(address);
     }
 
     private static Address recoverAddress(byte[] messageHash, String signatureHex) throws SignatureException, DecoderException {

--- a/src/main/java/com/streamr/client/utils/SigningUtil.java
+++ b/src/main/java/com/streamr/client/utils/SigningUtil.java
@@ -85,12 +85,7 @@ public class SigningUtil {
     }
 
     private static boolean verify(String data, String signature, Address address) throws SignatureException, DecoderException {
-        System.out.println("data=" + data);
-        System.out.println("signature=" + signature);
-        System.out.println("address=" + address);
-        Address foobar = recoverAddress(calculateMessageHash(data), signature);
-        System.out.println(foobar + " vs " + address + " " + foobar.equals(address));
-        return foobar.equals(address);
+        return recoverAddress(calculateMessageHash(data), signature).equals(address);
     }
 
     private static Address recoverAddress(byte[] messageHash, String signatureHex) throws SignatureException, DecoderException {

--- a/src/test/groovy/com/streamr/client/TestWebSocketServer.java
+++ b/src/test/groovy/com/streamr/client/TestWebSocketServer.java
@@ -21,7 +21,7 @@ import java.util.*;
 
 public class TestWebSocketServer extends WebSocketServer {
     private static final Logger log = LoggerFactory.getLogger(TestWebSocketServer.class);
-    private final MessageCreationUtil msgCreationUtil = new MessageCreationUtil(new Address("publisherId"), null);
+    private final MessageCreationUtil msgCreationUtil = new MessageCreationUtil(Address.createRandom(), null);
     private final LinkedList<ReceivedControlMessage> receivedControlMessages = new LinkedList<>();
     private final String wsUrl;
     private int checkedControlMessages = 0;

--- a/src/test/groovy/com/streamr/client/protocol/ResendFromRequestAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ResendFromRequestAdapterSpec.groovy
@@ -5,7 +5,7 @@ import com.streamr.client.protocol.control_layer.ResendFromRequest
 import com.streamr.client.protocol.message_layer.MessageRef
 import spock.lang.Specification
 
-class ResendFromRequestAdapterSpec extends Specification {
+class ResendFromRequestAdapterSpec extends StreamrSpecification {
 
 	def "serialization and deserialization"(String serializedMessage, ControlMessage message) {
 		expect:
@@ -14,7 +14,7 @@ class ResendFromRequestAdapterSpec extends Specification {
 
 		where:
 		serializedMessage | message
-		'[2,12,"requestId","streamId",0,[143415425455,0],"publisherId","sessionToken"]' | new ResendFromRequest("requestId", "streamId", 0, new MessageRef(143415425455L, 0L), "publisherId", "sessionToken")
+		'[2,12,"requestId","streamId",0,[143415425455,0],"' + publisherId + '","sessionToken"]' | new ResendFromRequest("requestId", "streamId", 0, new MessageRef(143415425455L, 0L), publisherId.toString(), "sessionToken")
 		'[2,12,"requestId","streamId",0,[143415425455,0],null,null]' | new ResendFromRequest("requestId", "streamId", 0, new MessageRef(143415425455L, 0L), null)
 	}
 

--- a/src/test/groovy/com/streamr/client/protocol/ResendRangeRequestAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/ResendRangeRequestAdapterSpec.groovy
@@ -13,12 +13,12 @@ class ResendRangeRequestAdapterSpec extends StreamrSpecification {
 
 		where:
 		serializedMessage | message
-		'[2,13,"requestId","streamId",0,[143415425455,0],[14341542564555,7],"publisherid","msgChainId","sessionToken"]' | new ResendRangeRequest("requestId", "streamId", 0, new MessageRef(143415425455L, 0L), new MessageRef(14341542564555L, 7L), publisherId, "msgChainId", "sessionToken")
+		'[2,13,"requestId","streamId",0,[143415425455,0],[14341542564555,7],"' + publisherId + '","msgChainId","sessionToken"]' | new ResendRangeRequest("requestId", "streamId", 0, new MessageRef(143415425455L, 0L), new MessageRef(14341542564555L, 7L), publisherId, "msgChainId", "sessionToken")
 		'[2,13,"requestId","streamId",0,[143415425455,0],[14341542564555,7],null,null,null]' | new ResendRangeRequest("requestId", "streamId", 0, new MessageRef(143415425455L, 0L), new MessageRef(14341542564555L, 7L), null)
 	}
 
 	void "fromJson (from > to)"() {
-		String serializedMessage = '[2,13,"requestId","streamId",0,[143415425455,0],[143415425000,0],"publisherId","msgChainId","sessionToken"]'
+		String serializedMessage = '[2,13,"requestId","streamId",0,[143415425455,0],[143415425000,0],"' + publisherId + '","msgChainId","sessionToken"]'
 
 		when:
 		ControlMessage.fromJson(serializedMessage)

--- a/src/test/groovy/com/streamr/client/protocol/StreamMessageExamples.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/StreamMessageExamples.groovy
@@ -9,13 +9,13 @@ class StreamMessageExamples {
 
     public static class InvalidSignature {
         public static final StreamMessage helloWorld = new StreamMessage(
-                new MessageID("7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, new Address("publisherId"), "1"),
+                new MessageID("7wa7APtlTq6EC5iTCBy6dw", 0, 1528228173462L, 0, new Address("0x1111111111111111111111111111111111111111"), "1"),
                 new MessageRef(1528228170000L, 0),
                 StreamMessage.MessageType.STREAM_MESSAGE, [hello: "world"], StreamMessage.EncryptionType.NONE, null,
                 StreamMessage.SignatureType.ETH, "signature")
 
-        public static final String helloWorldSerialized31 = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherid\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
-        public static final String helloWorldSerialized32 = "[32,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherid\",\"1\"],[1528228170000,0],27,0,0,null,\"{\\\"hello\\\":\\\"world\\\"}\",null,2,\"signature\"]"
+        public static final String helloWorldSerialized31 = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"0x1111111111111111111111111111111111111111\",\"1\"],[1528228170000,0],27,0,\"{\\\"hello\\\":\\\"world\\\"}\",2,\"signature\"]"
+        public static final String helloWorldSerialized32 = "[32,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"0x1111111111111111111111111111111111111111\",\"1\"],[1528228170000,0],27,0,0,null,\"{\\\"hello\\\":\\\"world\\\"}\",null,2,\"signature\"]"
     }
 
 

--- a/src/test/groovy/com/streamr/client/protocol/StreamMessageV30AdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/StreamMessageV30AdapterSpec.groovy
@@ -28,7 +28,7 @@ class StreamMessageV30AdapterSpec extends StreamrSpecification {
 	}
 
 	void "deserialize"() {
-		String json = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
+		String json = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"" + publisherId + "\",\"1\"],[1528228170000,0],27,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
 
 		when:
 		msg = StreamMessageAdapter.deserialize(json)
@@ -54,7 +54,7 @@ class StreamMessageV30AdapterSpec extends StreamrSpecification {
 	}
 
 	void "deserialize with previousMessageRef null"() {
-		String json = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,27,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
+		String json = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\""+ publisherId + "\",\"1\"],null,27,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
 
 		when:
 		msg = StreamMessageAdapter.deserialize(json)
@@ -78,7 +78,7 @@ class StreamMessageV30AdapterSpec extends StreamrSpecification {
 	}
 
 	void "deserialize with no signature"() {
-		String json = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,27,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",0,null]"
+		String json = "[30,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"" + publisherId + "\",\"1\"],null,27,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",0,null]"
 
 		when:
 		msg = StreamMessageAdapter.deserialize(json)

--- a/src/test/groovy/com/streamr/client/protocol/StreamMessageV31AdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/StreamMessageV31AdapterSpec.groovy
@@ -28,7 +28,7 @@ class StreamMessageV31AdapterSpec extends StreamrSpecification {
 	}
 
 	void "deserialize"() {
-		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],[1528228170000,0],27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
+		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"" + publisherId + "\",\"1\"],[1528228170000,0],27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
 
 		when:
 		msg = StreamMessageAdapter.deserialize(json)
@@ -54,7 +54,7 @@ class StreamMessageV31AdapterSpec extends StreamrSpecification {
 	}
 
 	void "deserialize with previousMessageRef null"() {
-		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
+		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"" + publisherId + "\",\"1\"],null,27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",2,\"signature\"]"
 
 		when:
 		msg = StreamMessageAdapter.deserialize(json)
@@ -78,7 +78,7 @@ class StreamMessageV31AdapterSpec extends StreamrSpecification {
 	}
 
 	void "deserialize with no signature"() {
-		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"publisherId\",\"1\"],null,27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",0,null]"
+		String json = "[31,[\"7wa7APtlTq6EC5iTCBy6dw\",0,1528228173462,0,\"" + publisherId + "\",\"1\"],null,27,0,\"{\\\"desi\\\":\\\"2\\\",\\\"dir\\\":\\\"1\\\",\\\"oper\\\":40,\\\"veh\\\":222,\\\"tst\\\":\\\"2018-06-05T19:49:33Z\\\",\\\"tsi\\\":1528228173,\\\"spd\\\":3.6,\\\"hdg\\\":69,\\\"lat\\\":60.192258,\\\"long\\\":24.928701,\\\"acc\\\":-0.59,\\\"dl\\\":-248,\\\"odo\\\":5134,\\\"drst\\\":0,\\\"oday\\\":\\\"2018-06-05\\\",\\\"jrn\\\":885,\\\"line\\\":30,\\\"start\\\":\\\"22:23\\\"}\",0,null]"
 
 		when:
 		msg = StreamMessageAdapter.deserialize(json)

--- a/src/test/groovy/com/streamr/client/protocol/StreamMessageV32AdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/StreamMessageV32AdapterSpec.groovy
@@ -25,7 +25,7 @@ class StreamMessageV32AdapterSpec extends StreamrSpecification {
 	}
 
 	void "serialize minimal message"() {
-		String expectedJson = '[32,["streamId",0,123,0,"publisherid","msgChainId"],null,27,0,0,null,"{}",null,0,null]'
+		String expectedJson = '[32,["streamId",0,123,0,"' + publisherId + '","msgChainId"],null,27,0,0,null,"{}",null,0,null]'
 
 		expect:
 		adapter.serialize(msg, VERSION) == expectedJson
@@ -33,7 +33,7 @@ class StreamMessageV32AdapterSpec extends StreamrSpecification {
 	}
 
 	void "serialize maximal message"() {
-		String expectedJson = '[32,["streamId",0,123,0,"publisherid","msgChainId"],[122,0],27,0,2,"groupKeyId","encrypted-content","[\\\"newGroupKeyId\\\",\\\"encryptedGroupKeyHex-cached\\\"]",2,"signature"]'
+		String expectedJson = '[32,["streamId",0,123,0,"' + publisherId + '","msgChainId"],[122,0],27,0,2,"groupKeyId","encrypted-content","[\\\"newGroupKeyId\\\",\\\"encryptedGroupKeyHex-cached\\\"]",2,"signature"]'
 		msg.setPreviousMessageRef(new MessageRef(122L, 0))
 		msg.setEncryptionType(StreamMessage.EncryptionType.AES);
 		msg.setGroupKeyId("groupKeyId")
@@ -47,7 +47,7 @@ class StreamMessageV32AdapterSpec extends StreamrSpecification {
 	}
 
 	void "deserialize minimal message"() {
-		String json = '[32,["streamId",0,123,0,"publisherid","msgChainId"],null,27,0,0,null,"{}",null,0,null]'
+		String json = '[32,["streamId",0,123,0,"' + publisherId + '","msgChainId"],null,27,0,0,null,"{}",null,0,null]'
 
 		when:
 		msg = StreamMessageAdapter.deserialize(json)
@@ -72,7 +72,7 @@ class StreamMessageV32AdapterSpec extends StreamrSpecification {
 	}
 
 	void "deserialize maximal message"() {
-		String json = '[32,["streamId",0,123,0,"publisherid","msgChainId"],[122,0],27,0,2,"groupKeyId","encrypted-content","[\\\"newGroupKeyId\\\",\\\"encryptedGroupKeyHex\\\"]",2,"signature"]'
+		String json = '[32,["streamId",0,123,0,"' + publisherId + '","msgChainId"],[122,0],27,0,2,"groupKeyId","encrypted-content","[\\\"newGroupKeyId\\\",\\\"encryptedGroupKeyHex\\\"]",2,"signature"]'
 
 		when:
 		msg = StreamMessageAdapter.deserialize(json)

--- a/src/test/groovy/com/streamr/client/protocol/StreamrSpecification.groovy
+++ b/src/test/groovy/com/streamr/client/protocol/StreamrSpecification.groovy
@@ -5,6 +5,9 @@ import com.streamr.client.protocol.message_layer.MessageRef
 import com.streamr.client.protocol.message_layer.StreamMessage
 import com.streamr.client.utils.Address
 import spock.lang.Specification
+import org.apache.commons.codec.binary.Hex
+
+import java.nio.ByteBuffer
 
 /**
  * Useful methods for subclasses to use
@@ -18,14 +21,21 @@ class StreamrSpecification extends Specification {
     final String subscriberPrivateKey = "81fe39ed83c4ab997f64564d0c5a630e34c621ad9bbe51ad2754fac575fc0c46"
     final Address subscriber = new Address("0xbe0ab87a1f5b09afe9101b09e3c86fd8f4162527")
 
-    protected static final Address subscriberId = new Address("subscriberId")
-    protected static final Address publisherId = new Address("publisherId")
+    protected static final Address subscriberId = Address.createRandom()
+    protected static final Address publisherId = Address.createRandom()
 
-    protected static Address getSubscriberId(int number) {
-        return new Address("subscriberId${number}")
+    protected static Address createMockAddress(int id, String type) {
+        ByteBuffer b = ByteBuffer.allocate(20)
+        b.putInt(0, type.hashCode())
+        b.putInt(16, id)
+        return new Address(b.array())
     }
-    protected static Address getPublisherId(int number) {
-        return new Address("publisherId${number}")
+
+    protected static Address getSubscriberId(int id) {
+        return createMockAddress(id, "subscriber")
+    }
+    protected static Address getPublisherId(int id) {
+        return createMockAddress(id, "publisher")
     }
 
     protected StreamMessage createMessage(Map content) {
@@ -36,7 +46,7 @@ class StreamrSpecification extends Specification {
         return createMessage(timestamp, 0, null, null, publisherId, content)
     }
 
-    protected StreamMessage createMessage(long timestamp = 0, long sequenceNumber = 0, Long previousTimestamp = null, Long previousSequenceNumber = null, Address publisherId = new Address("publisherId"), Map content = [:], String msgChainId = "msgChainId") {
+    protected StreamMessage createMessage(long timestamp = 0, long sequenceNumber = 0, Long previousTimestamp = null, Long previousSequenceNumber = null, Address publisherId = new Address("0x1111111111111111111111111111111111111111"), Map content = [:], String msgChainId = "msgChainId") {
         new StreamMessage(
                 new MessageID("streamId", 0, timestamp, sequenceNumber, publisherId, msgChainId),
                 (previousTimestamp != null ? new MessageRef(previousTimestamp, previousSequenceNumber ?: 0) : null),

--- a/src/test/groovy/com/streamr/client/utils/AddressSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/AddressSpec.groovy
@@ -1,0 +1,35 @@
+package com.streamr.client.utils
+
+import spock.lang.Specification
+
+class AddressSpec extends Specification {
+
+    def "Address.valid"() {
+        when:
+        Address address = new Address("0xabcdeabcde123456789012345678901234567890")
+		then:
+        address.toString() == "0xAbcdeabCDE123456789012345678901234567890"
+	}
+
+    def "Address.invalid"() {
+        when:
+        Address address = new Address("foobar")
+		then:
+        thrown IllegalArgumentException
+	}
+
+    def "Address.null"() {
+        when:
+        Address address = new Address((String) null)
+		then:
+        thrown IllegalArgumentException
+    }
+
+    def "Address.createRandom"() {
+        when:
+        Address address = Address.createRandom()
+		then:
+        address.toString().startsWith("0x")
+        address.toString().length() == 42
+    }
+}

--- a/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/OrderedMsgChainSpec.groovy
@@ -18,8 +18,6 @@ class OrderedMsgChainSpec extends StreamrSpecification {
     final StreamMessage msg4 = createMessage(4, 0, 3, 0)
     final StreamMessage msg5 = createMessage(5, 0, 4, 0)
 
-    final Address publisherId = new Address("0x12345")
-
     void "handles ordered messages in order"() {
         ArrayList<StreamMessage> received = []
         OrderedMsgChain util = new OrderedMsgChain(publisherId, "msgChainId", new Consumer<StreamMessage>() {

--- a/src/test/groovy/com/streamr/client/utils/SigningUtilSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/SigningUtilSpec.groovy
@@ -19,7 +19,7 @@ class SigningUtilSpec extends StreamrSpecification {
         String withoutPrefix = "23bead9b499af21c4c16e4511b3b6b08c3e22e76e0591f5ab5ba8d4c3a5b1820"
         account = ECKey.fromPrivate(new BigInteger(withoutPrefix, 16))
         address = new Address("0x" + Hex.encodeHexString(account.getAddress()))
-        assert address.toString() == "0xa5374e3C19f15E1847881979Dd0C6C9ffe846BD5".toLowerCase()
+        assert address.toString().toLowerCase() == "0xa5374e3C19f15E1847881979Dd0C6C9ffe846BD5".toLowerCase()
 
         signingUtil = new SigningUtil(account)
         msgId = new MessageID("streamId", 0, 425235315L, 0L, publisherId, "msgChainId")
@@ -35,7 +35,7 @@ class SigningUtilSpec extends StreamrSpecification {
 
     void "should correctly sign a StreamMessage with null previous ref"() {
         StreamMessage msg = new StreamMessage(msgId, null, [foo: 'bar'])
-        String expectedPayload = "streamId04252353150publisheridmsgChainId"+'{"foo":"bar"}'
+        String expectedPayload = "streamId04252353150" + publisherId + "msgChainId"+'{"foo":"bar"}'
         when:
         signingUtil.signStreamMessage(msg)
         then:
@@ -45,7 +45,7 @@ class SigningUtilSpec extends StreamrSpecification {
 
     void "should correctly sign a StreamMessage with non-null previous ref"() {
         StreamMessage msg = new StreamMessage(msgId, new MessageRef(100, 1), [foo: 'bar'])
-        String expectedPayload = "streamId04252353150publisheridmsgChainId1001"+'{"foo":"bar"}'
+        String expectedPayload = "streamId04252353150" + publisherId + "msgChainId1001"+'{"foo":"bar"}'
         when:
         signingUtil.signStreamMessage(msg)
         then:
@@ -56,7 +56,7 @@ class SigningUtilSpec extends StreamrSpecification {
     void "should correctly sign a StreamMessage with new group key"() {
         StreamMessage msg = new StreamMessage(msgId, new MessageRef(100, 1), [foo: 'bar'])
         msg.setNewGroupKey(new EncryptedGroupKey("groupKeyId", "keyHex"))
-        String expectedPayload = "streamId04252353150publisheridmsgChainId1001"+'{"foo":"bar"}'+'["groupKeyId","keyHex"]'
+        String expectedPayload = "streamId04252353150" + publisherId + "msgChainId1001"+'{"foo":"bar"}'+'["groupKeyId","keyHex"]'
         when:
         signingUtil.signStreamMessage(msg)
         then:

--- a/src/test/groovy/com/streamr/client/utils/SigningUtilSpec.groovy
+++ b/src/test/groovy/com/streamr/client/utils/SigningUtilSpec.groovy
@@ -35,7 +35,7 @@ class SigningUtilSpec extends StreamrSpecification {
 
     void "should correctly sign a StreamMessage with null previous ref"() {
         StreamMessage msg = new StreamMessage(msgId, null, [foo: 'bar'])
-        String expectedPayload = "streamId04252353150" + publisherId + "msgChainId"+'{"foo":"bar"}'
+        String expectedPayload = "streamId04252353150" + publisherId.toLowerCaseString() + "msgChainId"+'{"foo":"bar"}'
         when:
         signingUtil.signStreamMessage(msg)
         then:
@@ -45,7 +45,7 @@ class SigningUtilSpec extends StreamrSpecification {
 
     void "should correctly sign a StreamMessage with non-null previous ref"() {
         StreamMessage msg = new StreamMessage(msgId, new MessageRef(100, 1), [foo: 'bar'])
-        String expectedPayload = "streamId04252353150" + publisherId + "msgChainId1001"+'{"foo":"bar"}'
+        String expectedPayload = "streamId04252353150" + publisherId.toLowerCaseString() + "msgChainId1001"+'{"foo":"bar"}'
         when:
         signingUtil.signStreamMessage(msg)
         then:
@@ -56,7 +56,7 @@ class SigningUtilSpec extends StreamrSpecification {
     void "should correctly sign a StreamMessage with new group key"() {
         StreamMessage msg = new StreamMessage(msgId, new MessageRef(100, 1), [foo: 'bar'])
         msg.setNewGroupKey(new EncryptedGroupKey("groupKeyId", "keyHex"))
-        String expectedPayload = "streamId04252353150" + publisherId + "msgChainId1001"+'{"foo":"bar"}'+'["groupKeyId","keyHex"]'
+        String expectedPayload = "streamId04252353150" + publisherId.toLowerCaseString() + "msgChainId1001"+'{"foo":"bar"}'+'["groupKeyId","keyHex"]'
         when:
         signingUtil.signStreamMessage(msg)
         then:


### PR DESCRIPTION
Added validation to `Address` constructor: an invalid string throws an `IllegalArgumentException`.

Address.toString() returns the Ethereum address in checksum case (good format for the user interfaces etc.) In protocol level we sometimes need the address in lowercase format. That's why the internal format is in lowercase, and there is a `toLowerCaseString()` accessor to get that format efficiently.
