### PR TITLE
NET-178: Storage node endpoints

### DIFF
--- a/src/main/java/com/streamr/client/Streamr.java
+++ b/src/main/java/com/streamr/client/Streamr.java
@@ -4,7 +4,9 @@ import com.streamr.client.dataunion.DataUnionClient;
 import com.streamr.client.options.ResendOption;
 import com.streamr.client.rest.AmbiguousResultsException;
 import com.streamr.client.rest.Permission;
+import com.streamr.client.rest.StorageNode;
 import com.streamr.client.rest.Stream;
+import com.streamr.client.rest.StreamPart;
 import com.streamr.client.rest.StreamrRestClient;
 import com.streamr.client.rest.UserInfo;
 import com.streamr.client.subs.Subscription;
@@ -113,4 +115,14 @@ interface Streamr {
       final ResendOption resendOption);
 
   void unsubscribe(final Subscription sub);
+
+  void addStreamToStorageNode(final String streamId, final StorageNode storageNode)
+      throws IOException;
+
+  void removeStreamToStorageNode(final String streamId, final StorageNode storageNode)
+      throws IOException;
+
+  List<StorageNode> getStorageNodes(final String streamId) throws IOException;
+
+  List<StreamPart> getStreamPartsByStorageNode(final StorageNode storageNode) throws IOException;
 }

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -29,7 +29,9 @@ import com.streamr.client.protocol.message_layer.StreamMessage;
 import com.streamr.client.protocol.message_layer.StreamMessageValidator;
 import com.streamr.client.rest.AmbiguousResultsException;
 import com.streamr.client.rest.Permission;
+import com.streamr.client.rest.StorageNode;
 import com.streamr.client.rest.Stream;
+import com.streamr.client.rest.StreamPart;
 import com.streamr.client.rest.StreamrRestClient;
 import com.streamr.client.rest.UserInfo;
 import com.streamr.client.subs.BasicSubscription;
@@ -764,6 +766,26 @@ public class StreamrClient implements Streamr {
     sub.setState(Subscription.State.UNSUBSCRIBING);
     sub.setResending(false);
     send(unsubscribeRequest);
+  }
+
+  @Override
+  public void addStreamToStorageNode(final String streamId, final StorageNode storageNode) throws IOException {
+    restClient.addStreamToStorageNode(streamId, storageNode);
+  }
+
+  @Override
+  public void removeStreamToStorageNode(final String streamId, final StorageNode storageNode) throws IOException {
+    restClient.removeStreamToStorageNode(streamId, storageNode);
+  }
+
+  @Override
+  public List<StorageNode> getStorageNodes(final String streamId) throws IOException {
+    return restClient.getStorageNodes(streamId);
+  }
+
+  @Override
+  public List<StreamPart> getStreamPartsByStorageNode(final StorageNode storageNode) throws IOException {
+    return restClient.getStreamPartsByStorageNode(storageNode);
   }
 
   private void handleSubscribeResponse(SubscribeResponse res) throws SubscriptionNotFoundException {

--- a/src/main/java/com/streamr/client/StreamrClient.java
+++ b/src/main/java/com/streamr/client/StreamrClient.java
@@ -769,12 +769,14 @@ public class StreamrClient implements Streamr {
   }
 
   @Override
-  public void addStreamToStorageNode(final String streamId, final StorageNode storageNode) throws IOException {
+  public void addStreamToStorageNode(final String streamId, final StorageNode storageNode)
+      throws IOException {
     restClient.addStreamToStorageNode(streamId, storageNode);
   }
 
   @Override
-  public void removeStreamToStorageNode(final String streamId, final StorageNode storageNode) throws IOException {
+  public void removeStreamToStorageNode(final String streamId, final StorageNode storageNode)
+      throws IOException {
     restClient.removeStreamToStorageNode(streamId, storageNode);
   }
 
@@ -784,7 +786,8 @@ public class StreamrClient implements Streamr {
   }
 
   @Override
-  public List<StreamPart> getStreamPartsByStorageNode(final StorageNode storageNode) throws IOException {
+  public List<StreamPart> getStreamPartsByStorageNode(final StorageNode storageNode)
+      throws IOException {
     return restClient.getStreamPartsByStorageNode(storageNode);
   }
 

--- a/src/main/java/com/streamr/client/rest/AddressJsonAdapter.java
+++ b/src/main/java/com/streamr/client/rest/AddressJsonAdapter.java
@@ -3,7 +3,6 @@ package com.streamr.client.rest;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
-
 import com.streamr.client.utils.Address;
 import java.io.IOException;
 

--- a/src/main/java/com/streamr/client/rest/AddressJsonAdapter.java
+++ b/src/main/java/com/streamr/client/rest/AddressJsonAdapter.java
@@ -1,0 +1,20 @@
+package com.streamr.client.rest;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+
+import com.streamr.client.utils.Address;
+import java.io.IOException;
+
+public class AddressJsonAdapter extends JsonAdapter<Address> {
+  @Override
+  public Address fromJson(JsonReader reader) throws IOException {
+    return new Address(reader.nextString());
+  }
+
+  @Override
+  public void toJson(JsonWriter writer, Address value) throws IOException {
+    writer.value(value.toString());
+  }
+}

--- a/src/main/java/com/streamr/client/rest/Json.java
+++ b/src/main/java/com/streamr/client/rest/Json.java
@@ -2,6 +2,7 @@ package com.streamr.client.rest;
 
 import com.squareup.moshi.Moshi;
 import com.streamr.client.protocol.message_layer.StringOrMillisDateJsonAdapter;
+import com.streamr.client.utils.Address;
 import java.math.BigDecimal;
 import java.util.Date;
 
@@ -12,6 +13,7 @@ final class Json {
     return new Moshi.Builder()
         .add(Date.class, new StringOrMillisDateJsonAdapter().nullSafe())
         .add(BigDecimal.class, new BigDecimalAdapter().nullSafe())
+        .add(Address.class, new AddressJsonAdapter().nullSafe())
         .add(new InstantJsonAdapter());
   }
 }

--- a/src/main/java/com/streamr/client/rest/StorageNode.java
+++ b/src/main/java/com/streamr/client/rest/StorageNode.java
@@ -1,0 +1,15 @@
+package com.streamr.client.rest;
+
+import com.streamr.client.utils.Address;
+
+public final class StorageNode {
+  private final Address address;
+
+  public StorageNode(final Address address) {
+    this.address = address;
+  }
+
+  public Address getAddress() {
+    return this.address;
+  }
+}

--- a/src/main/java/com/streamr/client/rest/StorageNodeInput.java
+++ b/src/main/java/com/streamr/client/rest/StorageNodeInput.java
@@ -1,0 +1,14 @@
+package com.streamr.client.rest;
+
+import com.streamr.client.utils.Address;
+
+public final class StorageNodeInput {
+    private final Address storageNodeAddress;
+    public StorageNodeInput(Address storageNodeAddress) {
+        this.storageNodeAddress = storageNodeAddress;
+    }
+
+    public Address getStorageNodeAddress() {
+        return storageNodeAddress;
+    }
+}

--- a/src/main/java/com/streamr/client/rest/StorageNodeInput.java
+++ b/src/main/java/com/streamr/client/rest/StorageNodeInput.java
@@ -3,12 +3,13 @@ package com.streamr.client.rest;
 import com.streamr.client.utils.Address;
 
 public final class StorageNodeInput {
-    private final Address storageNodeAddress;
-    public StorageNodeInput(Address storageNodeAddress) {
-        this.storageNodeAddress = storageNodeAddress;
-    }
+  private final Address storageNodeAddress;
 
-    public Address getStorageNodeAddress() {
-        return storageNodeAddress;
-    }
+  public StorageNodeInput(Address storageNodeAddress) {
+    this.storageNodeAddress = storageNodeAddress;
+  }
+
+  public Address getStorageNodeAddress() {
+    return storageNodeAddress;
+  }
 }

--- a/src/main/java/com/streamr/client/rest/Stream.java
+++ b/src/main/java/com/streamr/client/rest/Stream.java
@@ -2,7 +2,9 @@ package com.streamr.client.rest;
 
 import com.streamr.client.java.util.Objects;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * {@code Stream} represents a Streamr Stream.
@@ -128,6 +130,14 @@ public final class Stream {
 
   public Date getLastUpdated() {
     return lastUpdated;
+  }
+
+  public List<StreamPart> toStreamParts() {
+    List<StreamPart> result = new ArrayList<>();
+    for (int i = 0; i < this.partitions; i++) {
+      result.add(new StreamPart(this.id, i));
+    }
+    return result;
   }
 
   @Override

--- a/src/main/java/com/streamr/client/rest/StreamPart.java
+++ b/src/main/java/com/streamr/client/rest/StreamPart.java
@@ -1,0 +1,19 @@
+package com.streamr.client.rest;
+
+public final class StreamPart {
+  private final String streamId;
+  private final int streamPartition;
+
+  public StreamPart(final String streamId, final int streamPartition) {
+    this.streamId = streamId;
+    this.streamPartition = streamPartition;
+  }
+
+  public String getStreamId() {
+    return this.streamId;
+  }
+
+  public int getStreamPartition() {
+    return this.streamPartition;
+  }
+}

--- a/src/main/java/com/streamr/client/rest/StreamrRestClient.java
+++ b/src/main/java/com/streamr/client/rest/StreamrRestClient.java
@@ -176,10 +176,12 @@ public class StreamrRestClient {
     return executeWithRetry(builder, adapter, retryIfSessionExpired);
   }
 
-  public void addStreamToStorageNode(final String streamId, final StorageNode storageNode) throws IOException {
+  public void addStreamToStorageNode(final String streamId, final StorageNode storageNode)
+      throws IOException {
     final JsonAdapter<StorageNode> storageNodeJsonAdapter =
         Json.newMoshiBuilder().build().adapter(StorageNode.class);
-    final JsonAdapter<Stream> streamJsonAdapter = Json.newMoshiBuilder().build().adapter(Stream.class);
+    final JsonAdapter<Stream> streamJsonAdapter =
+        Json.newMoshiBuilder().build().adapter(Stream.class);
     final HttpUrl url = getEndpointUrl("streams", streamId, "storageNodes");
     postWithRetry(url, storageNodeJsonAdapter.toJson(storageNode), streamJsonAdapter);
   }
@@ -203,8 +205,10 @@ public class StreamrRestClient {
         .collect(Collectors.toList());
   }
 
-  public List<StreamPart> getStreamPartsByStorageNode(final StorageNode storageNode) throws IOException {
-    final HttpUrl url = getEndpointUrl("storageNodes", storageNode.getAddress().toString(), "streams");
+  public List<StreamPart> getStreamPartsByStorageNode(final StorageNode storageNode)
+      throws IOException {
+    final HttpUrl url =
+        getEndpointUrl("storageNodes", storageNode.getAddress().toString(), "streams");
     final JsonAdapter<List<Stream>> streamListJsonAdapter =
         Json.newMoshiBuilder()
             .build()

--- a/src/test/groovy/com/streamr/client/rest/AddressJsonAdapterSpec.groovy
+++ b/src/test/groovy/com/streamr/client/rest/AddressJsonAdapterSpec.groovy
@@ -1,0 +1,47 @@
+package com.streamr.client.rest
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.Moshi
+import com.streamr.client.utils.Address
+import java.nio.charset.StandardCharsets
+import okio.Buffer
+import spock.lang.Specification
+
+class TestWrapper {
+	Address address
+
+	TestWrapper(Address address) {
+		this.address = address
+	}
+}
+
+class AddressJsonAdapterSpec extends Specification {
+	private static JsonReader toReader(String json) {
+		return JsonReader.of(new Buffer().writeString(json, StandardCharsets.UTF_8))
+	}
+	private JsonAdapter<TestWrapper> adapter = new Moshi.Builder()
+			.add(Address.class, new AddressJsonAdapter().nullSafe())
+			.build()
+			.adapter(TestWrapper.class)
+
+	def "Address.fromJson"(String json, Address address) {
+		expect:
+		println(json)
+		adapter.fromJson(toReader(json)).address == address
+		where:
+		json | address
+		"{\"address\": \"0x1111111111111111111111111111111111111111\"}" | new Address("0x1111111111111111111111111111111111111111")
+		"{\"address\": null}" | null
+		"{}" | null
+	}
+
+	def "Address.toJson"(Address address, String json) {
+		expect:
+		adapter.toJson(new TestWrapper(address)) == json
+		where:
+		address | json
+		new Address("0x2222222222222222222222222222222222222222") | "{\"address\":\"0x2222222222222222222222222222222222222222\"}"
+		null | "{}"
+	}
+}

--- a/src/test/java/com/streamr/client/testing/TestingAddresses.java
+++ b/src/test/java/com/streamr/client/testing/TestingAddresses.java
@@ -1,6 +1,7 @@
 package com.streamr.client.testing;
 
 import com.streamr.client.utils.Address;
+import java.util.Random;
 
 public final class TestingAddresses {
   public static final Address SUBSCRIBER_ID = new Address("subscriberId");
@@ -14,5 +15,11 @@ public final class TestingAddresses {
 
   public static Address createPublisherId(final int number) {
     return new Address("publisherId" + String.valueOf(number));
+  }
+
+  public static Address createRandom() {
+    byte[] array = new byte[20];
+    new Random().nextBytes(array);
+    return new Address(array);
   }
 }


### PR DESCRIPTION
Ported PR https://github.com/streamr-dev/streamr-client-java/pull/150 to release/v3.0.0 branch.

Added methods to storage node query/modification:
- addStreamToStorageNode
- removeStreamToStorageNode
- getStorageNodes
- getStreamPartsByStorageNode

The methods use new entity classes: StorageNode and StreamPart. Both are currently minimal without any no business logic. We'll add more methods to the classes in the future.

Added also new AddressJsonAdapter to support the JSON serialization/deserialization of Address class.