### PR TITLE
NET-286: Storage node constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ You create streams via the `create(Stream)` method, passing in a prototype `Stre
 
 ```java
 Stream created = client.createStream(new Stream("Stream name", "Stream description"));
+// Optional: to enable historical data resends, add the stream to a storage node
+client.addStreamToStorageNode(created.getId(), StorageNode.STREAMR_GERMANY);
 ```
 
 <a name="looking-up-streams"></a>

--- a/client/src/integrationTest/groovy/com/streamr/client/rest/StreamEndpointsSpec.groovy
+++ b/client/src/integrationTest/groovy/com/streamr/client/rest/StreamEndpointsSpec.groovy
@@ -257,7 +257,7 @@ class StreamEndpointsSpec extends Specification {
         StorageNode storageNode = new StorageNode(TestingAddresses.createRandom())
         client.addStreamToStorageNode(streamId, storageNode)
         when:
-        client.removeStreamToStorageNode(streamId, storageNode)
+        client.removeStreamFromStorageNode(streamId, storageNode)
         List<StorageNode> storageNodes = client.getStorageNodes(streamId)
         then:
         storageNodes.size() == 0

--- a/client/src/main/java/com/streamr/client/Streamr.java
+++ b/client/src/main/java/com/streamr/client/Streamr.java
@@ -121,7 +121,7 @@ interface Streamr {
   void addStreamToStorageNode(final String streamId, final StorageNode storageNode)
       throws IOException;
 
-  void removeStreamToStorageNode(final String streamId, final StorageNode storageNode)
+  void removeStreamFromStorageNode(final String streamId, final StorageNode storageNode)
       throws IOException;
 
   List<StorageNode> getStorageNodes(final String streamId) throws IOException;

--- a/client/src/main/java/com/streamr/client/StreamrClient.java
+++ b/client/src/main/java/com/streamr/client/StreamrClient.java
@@ -776,9 +776,9 @@ public class StreamrClient implements Streamr {
   }
 
   @Override
-  public void removeStreamToStorageNode(final String streamId, final StorageNode storageNode)
+  public void removeStreamFromStorageNode(final String streamId, final StorageNode storageNode)
       throws IOException {
-    restClient.removeStreamToStorageNode(streamId, storageNode);
+    restClient.removeStreamFromStorageNode(streamId, storageNode);
   }
 
   @Override

--- a/client/src/main/java/com/streamr/client/rest/StorageNode.java
+++ b/client/src/main/java/com/streamr/client/rest/StorageNode.java
@@ -3,6 +3,9 @@ package com.streamr.client.rest;
 import com.streamr.client.utils.Address;
 
 public final class StorageNode {
+  public static final StorageNode STREAMR_GERMANY = new StorageNode(new Address("0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916"));
+  public static final StorageNode STREAMR_DOCKER_DEV = new StorageNode(new Address("0xde1112f631486CfC759A50196853011528bC5FA0"));
+
   private final Address address;
 
   public StorageNode(final Address address) {

--- a/client/src/main/java/com/streamr/client/rest/StreamrRestClient.java
+++ b/client/src/main/java/com/streamr/client/rest/StreamrRestClient.java
@@ -228,7 +228,7 @@ public class StreamrRestClient {
     postWithRetry(url, storageNodeJsonAdapter.toJson(storageNode), streamJsonAdapter);
   }
 
-  public void removeStreamToStorageNode(final String streamId, final StorageNode storageNode)
+  public void removeStreamFromStorageNode(final String streamId, final StorageNode storageNode)
       throws IOException {
     final HttpUrl url =
         getEndpointUrl("streams", streamId, "storageNodes", storageNode.getAddress().toString());


### PR DESCRIPTION
Added constants StorageNode.STREAMR_GERMANY and StorageNode.STREAMR_DOCKER_DEV. The values are instances of StorageNode class.

Fixed also typo in method `removeStreamFromStorageNode` name.