### PR TITLE
NET-235: Create stream by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ If no error message handler is register then the error is logged.
 <a name="creating-streams"></a>
 ## Creating streams
 
-You create streams via the `create(Stream)` method, passing in a prototype `Stream` object with fields set as you wish. The method returns the `Stream` object that was actually created.
+You create streams via the `create(Stream)` method, passing in a prototype `Stream` object with fields set as you wish. The method returns the `Stream` object that was actually created. If you specify `id`, it can be a full streamId or a path (e.g. `/foo/bar` will create a stream with id `<your-ethereum-address>/foo/bar` if you have authenticated with a private key)
 
 ```java
 Stream created = client.createStream(new Stream("Stream name", "Stream description"));

--- a/client/src/integrationTest/groovy/com/streamr/client/rest/StreamEndpointsSpec.groovy
+++ b/client/src/integrationTest/groovy/com/streamr/client/rest/StreamEndpointsSpec.groovy
@@ -98,58 +98,6 @@ class StreamEndpointsSpec extends Specification {
         getResult.name == createResult.name
     }
 
-    void "createStream() without streamId"() {
-        Stream proto = new Stream.Builder()
-            .createStream()
-
-        when:
-        Stream createResult = client.createStream(proto)
-
-        then:
-        createResult.getId() != null
-    }
-
-    void "createStream() full streamId"() {
-        String path = "/foobar-" + System.currentTimeMillis()
-        String address = Keys.privateKeyToAddressWithPrefix(privateKey)
-        Stream proto = new Stream.Builder()
-            .withId(address + path)
-            .createStream()
-
-        when:
-        Stream createResult = client.createStream(proto)
-
-        then:
-        createResult.getId() == address + path
-    }
-
-    void "createStream() path streamId"() {
-        String address = Keys.privateKeyToAddressWithPrefix(privateKey)
-        String path = "/foobar-" + System.currentTimeMillis()
-        Stream proto = new Stream.Builder()
-            .withId(path)
-            .createStream()
-
-        when:
-        Stream createResult = client.createStream(proto)
-
-        then:
-        createResult.getId() == address.toLowerCase() + path
-    }
-
-
-    void "getStreamByName() path streamId, no authentication"() {
-        Stream proto = new Stream.Builder()
-            .withId("/foobar-" + System.currentTimeMillis())
-            .createStream()
-
-        when:
-        Stream createResult = TestingStreamrClient.createUnauthenticatedClient().createStream(proto)
-
-        then:
-        thrown(AuthenticationException)
-    }
-
     void "getStreamByName() throws ResourceNotFoundException if no such stream is found"() {
         when:
         client.getStreamByName("non-existent for sure " + System.currentTimeMillis())

--- a/client/src/integrationTest/groovy/com/streamr/client/rest/StreamEndpointsSpec.groovy
+++ b/client/src/integrationTest/groovy/com/streamr/client/rest/StreamEndpointsSpec.groovy
@@ -134,7 +134,7 @@ class StreamEndpointsSpec extends Specification {
         Stream createResult = client.createStream(proto)
 
         then:
-        createResult.getId() == address + path
+        createResult.getId() == address.toLowerCase() + path
     }
 
 

--- a/client/src/integrationTest/groovy/com/streamr/client/rest/StreamEndpointsSpec.groovy
+++ b/client/src/integrationTest/groovy/com/streamr/client/rest/StreamEndpointsSpec.groovy
@@ -98,6 +98,57 @@ class StreamEndpointsSpec extends Specification {
         getResult.name == createResult.name
     }
 
+    void "createStream() without streamId"() {
+        Stream proto = new Stream.Builder()
+            .createStream()
+
+        when:
+        Stream createResult = client.createStream(proto)
+
+        then:
+        createResult.getId() != null
+    }
+
+    void "createStream() full streamId"() {
+        String path = "/foobar-" + System.currentTimeMillis()
+        String address = Keys.privateKeyToAddressWithPrefix(privateKey)
+        Stream proto = new Stream.Builder()
+            .withId(address + path)
+            .createStream()
+
+        when:
+        Stream createResult = client.createStream(proto)
+
+        then:
+        createResult.getId() == address + path
+    }
+
+    void "createStream() path streamId"() {
+        String address = Keys.privateKeyToAddressWithPrefix(privateKey)
+        String path = "/foobar-" + System.currentTimeMillis()
+        Stream proto = new Stream.Builder()
+            .withId(path)
+            .createStream()
+
+        when:
+        Stream createResult = client.createStream(proto)
+
+        then:
+        createResult.getId() == address + path
+    }
+
+
+    void "getStreamByName() path streamId, no authentication"() {
+        Stream proto = new Stream.Builder()
+            .withId("/foobar-" + System.currentTimeMillis())
+            .createStream()
+
+        when:
+        Stream createResult = TestingStreamrClient.createUnauthenticatedClient().createStream(proto)
+
+        then:
+        thrown(AuthenticationException)
+    }
 
     void "getStreamByName() throws ResourceNotFoundException if no such stream is found"() {
         when:

--- a/client/src/integrationTest/java/com/streamr/client/rest/StreamrRestClientTest.java
+++ b/client/src/integrationTest/java/com/streamr/client/rest/StreamrRestClientTest.java
@@ -1,23 +1,66 @@
 package com.streamr.client.rest;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.streamr.client.crypto.Keys;
 import com.streamr.client.testing.TestingKeys;
 import com.streamr.client.testing.TestingMeta;
 import java.io.IOException;
 import java.math.BigInteger;
+
+import com.streamr.client.testing.TestingStreamrClient;
 import org.junit.jupiter.api.Test;
 
 class StreamrRestClientTest {
   @Test
   void newSessionTokenFetchesNewSessionTokenBySigningChallenge() throws IOException {
     final BigInteger privateKey = TestingKeys.generatePrivateKey();
-    final StreamrRestClient auth =
-        new StreamrRestClient.Builder()
-            .withRestApiUrl(TestingMeta.REST_URL)
-            .withPrivateKey(privateKey)
-            .createStreamrRestClient();
+    final StreamrRestClient auth = createClient(privateKey);
     final LoginResponse loginResponse = auth.login(privateKey);
     assertNotNull(loginResponse.getToken());
+  }
+
+  @Test
+  void createStream_withoutStreamId() throws IOException {
+    Stream proto = new Stream.Builder().createStream();
+    Stream actual = createClient(TestingKeys.generatePrivateKey()).createStream(proto);
+    assertNotNull(actual.getId());
+  }
+
+  @Test
+  void createStream_fullStreamId() throws IOException {
+    BigInteger privateKey = TestingKeys.generatePrivateKey();
+    String path = "/foobar-" + System.currentTimeMillis();
+    String address = Keys.privateKeyToAddressWithPrefix(privateKey);
+    Stream proto = new Stream.Builder().withId(address + path).createStream();
+    Stream actual = createClient(privateKey).createStream(proto);
+    assertEquals(address + path, actual.getId());
+  }
+
+  @Test
+  void createStream_pathStreamId() throws IOException {
+    BigInteger privateKey = TestingKeys.generatePrivateKey();
+    String address = Keys.privateKeyToAddressWithPrefix(privateKey);
+    String path = "/foobar-" + System.currentTimeMillis();
+    Stream proto = new Stream.Builder().withId(path).createStream();
+    Stream actual = createClient(privateKey).createStream(proto);
+    assertEquals(address.toLowerCase() + path, actual.getId());
+  }
+
+  @Test
+  void getStreamByName_pathStreamId_noAuthentication() {
+    assertThrows(AuthenticationException.class, () -> {
+      Stream proto = new Stream.Builder().withId("/foobar-" + System.currentTimeMillis()).createStream();
+      TestingStreamrClient.createUnauthenticatedClient().createStream(proto);
+    });
+  }
+
+  private StreamrRestClient createClient(BigInteger privateKey) {
+    return new StreamrRestClient.Builder()
+      .withRestApiUrl(TestingMeta.REST_URL)
+      .withPrivateKey(privateKey)
+      .createStreamrRestClient();
   }
 }

--- a/client/src/main/java/com/streamr/client/rest/Json.java
+++ b/client/src/main/java/com/streamr/client/rest/Json.java
@@ -1,10 +1,14 @@
 package com.streamr.client.rest;
 
 import com.squareup.moshi.Moshi;
+import com.squareup.moshi.JsonAdapter;
 import com.streamr.client.protocol.message_layer.StringOrMillisDateJsonAdapter;
 import com.streamr.client.utils.Address;
+
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.Map;
 
 final class Json {
   private Json() {}
@@ -15,5 +19,13 @@ final class Json {
         .add(BigDecimal.class, new BigDecimalAdapter().nullSafe())
         .add(Address.class, new AddressJsonAdapter().nullSafe())
         .add(new InstantJsonAdapter());
+  }
+
+  public static String withValue(String json, String key, String value) throws IOException {
+    JsonAdapter<Object> adapter = Json.newMoshiBuilder().build().adapter(Object.class);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> jsonObject = (Map<String,Object>) adapter.fromJson(json);
+    jsonObject.put(key, value);
+    return adapter.toJson(jsonObject);
   }
 }

--- a/client/src/main/java/com/streamr/client/rest/Stream.java
+++ b/client/src/main/java/com/streamr/client/rest/Stream.java
@@ -1,6 +1,7 @@
 package com.streamr.client.rest;
 
 import com.streamr.client.java.util.Objects;
+import com.streamr.client.utils.Address;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -270,5 +271,18 @@ public final class Stream {
           dateCreated,
           lastUpdated);
     }
+  }
+
+  public static String createStreamId(String streamIdOrPath, Address owner) {
+    if (streamIdOrPath == null) {
+        throw new IllegalArgumentException("Missing stream id");
+    }
+    if (!streamIdOrPath.startsWith("/")) {
+        return streamIdOrPath;
+    }
+    if (owner == null) {
+        throw new Error("Owner missing for stream id: " + streamIdOrPath);
+    }
+    return owner.toString().toLowerCase() + streamIdOrPath;
   }
 }

--- a/client/src/main/java/com/streamr/client/rest/StreamrRestClient.java
+++ b/client/src/main/java/com/streamr/client/rest/StreamrRestClient.java
@@ -302,8 +302,18 @@ public class StreamrRestClient {
   public Stream createStream(final Stream stream) throws IOException {
     final HttpUrl url = getEndpointUrl("streams");
     final JsonAdapter<Stream> streamJsonAdapter =
-        Json.newMoshiBuilder().build().adapter(Stream.class);
-    return postWithRetry(url, streamJsonAdapter.toJson(stream), streamJsonAdapter);
+      Json.newMoshiBuilder().build().adapter(Stream.class);
+    String json = streamJsonAdapter.toJson(stream);
+    if (stream.getId() != null) {
+      if (this.privateKey == null) {
+        throw new AuthenticationException("No private key");
+      }
+      String fullId = Stream.createStreamId(stream.getId(), new Address(Keys.privateKeyToAddressWithPrefix(this.privateKey)));
+      if (fullId != stream.getId()) {
+         json = Json.withValue(json, "id", fullId);
+      }
+    }
+    return postWithRetry(url, json, streamJsonAdapter);
   }
 
   public Permission grant(

--- a/client/src/test/java/com/streamr/client/rest/JsonTest.java
+++ b/client/src/test/java/com/streamr/client/rest/JsonTest.java
@@ -1,0 +1,41 @@
+package com.streamr.client.rest;
+
+import org.apache.groovy.json.internal.IO;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JsonTest {
+  @Test
+  public void withValue() throws IOException {
+    String from = "{\"foo\": \"x\", \"bar\": \"123\"}";
+    String to = Json.withValue(from, "foo", "y");
+    assertEquals("{\"foo\":\"y\",\"bar\":\"123\"}", to);
+  }
+
+  @Test
+  public void withValue_noPreviousValue() throws IOException {
+    String from = "{ \"bar\": \"456\"}";
+    String to = Json.withValue(from, "foo", "z");
+    assertEquals("{\"bar\":\"456\",\"foo\":\"z\"}", to);
+  }
+
+  @Test
+  public void withValue_array() {
+    assertThrows(IOException.class, () -> {
+      String from = "[]";
+      Json.withValue(from, "foo", "x");
+    });
+  }
+
+  @Test
+  public void withValue_invalidJson() {
+    assertThrows(IOException.class, () -> {
+      String from = "invalid-data";
+      Json.withValue(from, "foo", "x");
+    });
+  }
+}


### PR DESCRIPTION
The `id` parameter of `client.createStream` can  be a path (or full stream id, as previously). It will be prefixed with a lowercased Ethereum address derived from user's private key.

E.g. 
```
Stream proto = new Stream.Builder().withId("/foo/bar").createStream()
client.createStream(proto)
// -> creates 0xabcdeabcde123456789012345678901234567890/foo/bar
```