### PR TITLE
fix: move inner class out

### DIFF
--- a/src/main/java/com/streamr/client/authentication/Challenge.java
+++ b/src/main/java/com/streamr/client/authentication/Challenge.java
@@ -1,0 +1,9 @@
+package com.streamr.client.authentication;
+
+import java.util.Date;
+
+public class Challenge {
+    String id;
+    String challenge;
+    Date expires;
+}

--- a/src/main/java/com/streamr/client/authentication/EthereumAuthenticationMethod.java
+++ b/src/main/java/com/streamr/client/authentication/EthereumAuthenticationMethod.java
@@ -66,12 +66,6 @@ public class EthereumAuthenticationMethod extends AuthenticationMethod {
         return SigningUtil.sign(challengeToSign, account);
     }
 
-    static class Challenge {
-        String id;
-        String challenge;
-        Date expires;
-    }
-
     static class ChallengeResponse {
         Challenge challenge;
         String signature;


### PR DESCRIPTION
Android build seems to mangle the Challenge class such that moshi reflection only finds one field "a" on it

Maybe it's because it's an inner class? Attempt to avoid the mangling by moving it outside.